### PR TITLE
Enabling IoT Extensions SDK for UWP and startup task support.

### DIFF
--- a/Help/manual/cmake-properties.7.rst
+++ b/Help/manual/cmake-properties.7.rst
@@ -242,6 +242,8 @@ Properties on Targets
    /prop_tgt/VS_GLOBAL_PROJECT_TYPES
    /prop_tgt/VS_GLOBAL_ROOTNAMESPACE
    /prop_tgt/VS_GLOBAL_variable
+   /prop_tgt/VS_IOT_EXTENSIONS_VERSION
+   /prop_tgt/VS_IOT_STARTUP_TASK
    /prop_tgt/VS_KEYWORD
    /prop_tgt/VS_MOBILE_EXTENSIONS_VERSION
    /prop_tgt/VS_SCC_AUXPATH

--- a/Help/prop_tgt/VS_IOT_EXTENSIONS_VERSION.rst
+++ b/Help/prop_tgt/VS_IOT_EXTENSIONS_VERSION.rst
@@ -1,0 +1,11 @@
+VS_IOT_EXTENSIONS_VERSION
+----------------------------
+
+Visual Studio Windows 10 IoT Extensions Version
+
+Specifies the version of the IoT Extensions that should be included in the
+target. For example 1.0.0.1. If the value is not specified, the IoT
+Extensions will not be included.
+
+This is a prerelease way of targeting extensions and might change in a future
+version

--- a/Help/prop_tgt/VS_IOT_STARTUP_TASK.rst
+++ b/Help/prop_tgt/VS_IOT_STARTUP_TASK.rst
@@ -1,0 +1,9 @@
+VS_IOT_STARTUP_TASK
+----------------------------
+
+Visual Studio Windows 10 IoT Continuous Background Task
+
+Specifies that the target should be compiled as a Continuous Background Task library.
+
+This is a prerelease way of defining this property and might change in a future
+version

--- a/Source/cmVisualStudio10TargetGenerator.cxx
+++ b/Source/cmVisualStudio10TargetGenerator.cxx
@@ -2780,7 +2780,10 @@ void cmVisualStudio10TargetGenerator::WriteSDKReferences()
       this->Target->GetProperty("VS_DESKTOP_EXTENSIONS_VERSION");
     const char* mobileExtensionsVersion =
       this->Target->GetProperty("VS_MOBILE_EXTENSIONS_VERSION");
-    if(desktopExtensionsVersion || mobileExtensionsVersion)
+    const char* iotExtensionsVersion =
+      this->Target->GetProperty("VS_IOT_EXTENSIONS_VERSION");
+
+    if(desktopExtensionsVersion || mobileExtensionsVersion || iotExtensionsVersion)
       {
       this->WriteString("<ItemGroup>\n", 1);
       if(desktopExtensionsVersion)
@@ -2792,6 +2795,11 @@ void cmVisualStudio10TargetGenerator::WriteSDKReferences()
         {
         this->WriteSingleSDKReference("WindowsMobile",
                                       mobileExtensionsVersion);
+        }
+      if(iotExtensionsVersion)
+        {
+        this->WriteSingleSDKReference("WindowsIoT",
+                                      iotExtensionsVersion);
         }
       this->WriteString("</ItemGroup>\n", 1);
       }
@@ -2999,6 +3007,12 @@ void cmVisualStudio10TargetGenerator::WriteApplicationTypeSettings()
     this->WriteString("<WindowsTargetPlatformMinVersion>", 2);
     (*this->BuildFileStream) << cmVS10EscapeXML("10.0.10240.0") <<
       "</WindowsTargetPlatformMinVersion>\n";
+  }
+  
+  // Added IoT Startup Task support
+  if(this->Target->GetPropertyAsBool("VS_IOT_STARTUP_TASK"))
+  {
+    this->WriteString("<ContainsStartupTask>true</ContainsStartupTask>\n", 2);
   }
 }
 


### PR DESCRIPTION
The Windows 10 IoT Core has an Extension SDK for UWP.  It also supports UWP tasks that can startup with the embedded device and run in the background.

The VS_IOT_EXTENSIONS_VERSION property functions exactly like the Desktop and Mobile extension support.  The added VS_IOT_STARTUP_TASK property is a Boolean for enabling the project to be run as a background task.
