### PR TITLE
Do not specify ProjectPriFullPath. This property is calculated.

### DIFF
--- a/Source/cmVisualStudio10TargetGenerator.cxx
+++ b/Source/cmVisualStudio10TargetGenerator.cxx
@@ -2847,8 +2847,6 @@ void cmVisualStudio10TargetGenerator::WriteWinRTPackageCertificateKeyFile()
       this->WriteString("<AppxPackageArtifactsDir>", 2);
       (*this->BuildFileStream) << cmVS10EscapeXML(artifactDir) <<
         "\\</AppxPackageArtifactsDir>\n";
-      this->WriteString("<ProjectPriFullPath>"
-        "$(TargetDir)resources.pri</ProjectPriFullPath>\n", 2);
 
       // If we are missing files and we don't have a certificate and
       // aren't targeting WP8.0, add a default certificate


### PR DESCRIPTION
Hi @khouzam,

I'm find that specifying ProjectPriFullPath in the vcxproj file results in the resources.pri file being generated in the "wrong place". This causes an error during deployment. Simply removing this property fixes the problem because MSBUILD calculates it. 
FWIW, VS 2015 does not place this property into the default vcxproj files it generates.

Albert
