### PR TITLE
Support Visual C++ for Mobile Development targeting Android.

### DIFF
--- a/Help/manual/cmake-properties.7.rst
+++ b/Help/manual/cmake-properties.7.rst
@@ -277,6 +277,9 @@ Properties on Targets
    /prop_tgt/WINDOWS_EXPORT_ALL_SYMBOLS
    /prop_tgt/XCODE_ATTRIBUTE_an-attribute
    /prop_tgt/XCTEST
+   /prop_tgt/VC_MDD_ANDROID_USE_OF_STL
+   /prop_tgt/VC_MDD_ANDROID_API_LEVEL
+   /prop_tgt/VC_MDD_ANDROID_PLATFORM_TOOLSET
 
 .. _`Test Properties`:
 

--- a/Help/manual/cmake-toolchains.7.rst
+++ b/Help/manual/cmake-toolchains.7.rst
@@ -292,3 +292,20 @@ See also target properties:
 * :prop_tgt:`ANDROID_SECURE_PROPS_PATH`
 * :prop_tgt:`ANDROID_SKIP_ANT_STEP`
 * :prop_tgt:`ANDROID_STL_TYPE`
+
+Cross Compiling using Visual C++ for Mobile Development (Android support)
+-----------------------------------------
+
+A toolchain file to configure a Visual Studio generator to
+build using Visual C++ for Mobile Development targeting Android may look
+like this:
+
+.. code-block:: cmake
+
+  set(CMAKE_SYSTEM_NAME VCMDDAndroid)
+  set(CMAKE_SYSTEM_VERSION 1.0)
+
+See the :prop_tgt:`VC_MDD_ANDROID_USE_OF_STL`, :prop_tgt:`VC_MDD_ANDROID_API_LEVEL`
+and :prop_tgt:`VC_MDD_ANDROID_PLATFORM_TOOLSET` target properties
+to configure targets within the project.
+

--- a/Help/manual/cmake-variables.7.rst
+++ b/Help/manual/cmake-variables.7.rst
@@ -99,6 +99,9 @@ Variables that Provide Information
    /variable/PROJECT_VERSION_MINOR
    /variable/PROJECT_VERSION_PATCH
    /variable/PROJECT_VERSION_TWEAK
+   /variable/VC_MDD
+   /variable/VC_MDD_ANDROID
+   /variable/VC_MDD_ANDROID_VERSION
 
 Variables that Change Behavior
 ==============================
@@ -209,6 +212,8 @@ Variables that Describe the System
    /variable/WINDOWS_PHONE
    /variable/WINDOWS_STORE
    /variable/XCODE_VERSION
+   /variable/VC_MDD_ANDROID
+   /variable/VC_MDD_ANDROID_VERSION
 
 Variables that Control the Build
 ================================

--- a/Help/prop_tgt/VC_MDD_ANDROID_API_LEVEL.rst
+++ b/Help/prop_tgt/VC_MDD_ANDROID_API_LEVEL.rst
@@ -1,0 +1,4 @@
+VC_MDD_ANDROID_API_LEVEL
+------------------------------
+
+Set the Android NDK API Level targeted.

--- a/Help/prop_tgt/VC_MDD_ANDROID_PLATFORM_TOOLSET.rst
+++ b/Help/prop_tgt/VC_MDD_ANDROID_PLATFORM_TOOLSET.rst
@@ -1,0 +1,15 @@
+VC_MDD_ANDROID_PLATFORM_TOOLSET
+---------------------------------
+
+Set the toolset used for building the target.
+Both Clang and GCC are supported.
+
+This is a string property, currently the following are supported:
+
+* ``Clang_3_4``
+* ``Clang_3_6``
+* ``Gcc_4_9``
+
+Support for other toolsets might be added or removed.
+
+If set, it overrides the default.

--- a/Help/prop_tgt/VC_MDD_ANDROID_USE_OF_STL.rst
+++ b/Help/prop_tgt/VC_MDD_ANDROID_USE_OF_STL.rst
@@ -1,0 +1,19 @@
+VC_MDD_ANDROID_USE_OF_STL
+------------------------------
+
+Set the C++ Standard Library to use.
+
+This is a string property that could be set to the one of
+the following values:
+
+* ``system``: "Minimal C++ runtime library (system)"
+* ``gabi++_static``: "C++ runtime static library (gabi++_static)"
+* ``gabi++_shared``: "C++ runtime shared library (gabi++_shared)"
+* ``stlport_static``: "STLport runtime static library (stlport_static)"
+* ``stlport_shared``: "STLport runtime shared library (stlport_shared)"
+* ``gnustl_static``: "GNU STL static library (gnustl_static)"
+* ``gnustl_shared``: "GNU STL shared library (gnustl_shared)"
+* ``c++_static``: "LLVM libc++ static library (c++_static)"
+* ``c++_shared``: "LLVM libc++ shared library (c++_shared)"
+
+If set, it overrides the default.

--- a/Help/release/dev/vc-mdd-android.rst
+++ b/Help/release/dev/vc-mdd-android.rst
@@ -1,0 +1,5 @@
+vc-mdd-android
+--------------------------
+
+* The :ref:`Visual Studio Generators` learned to support
+  Visual C++ for Mobile Development targeting Android.

--- a/Help/variable/VC_MDD.rst
+++ b/Help/variable/VC_MDD.rst
@@ -1,0 +1,5 @@
+VC_MDD
+-------------
+
+True when the :variable:`CMAKE_SYSTEM_NAME` variable is set
+to ``VCMDDAndroid``.

--- a/Help/variable/VC_MDD_ANDROID.rst
+++ b/Help/variable/VC_MDD_ANDROID.rst
@@ -1,0 +1,5 @@
+VC_MDD_ANDROID
+---------------
+
+True when the :variable:`CMAKE_SYSTEM_NAME` variable is set
+to ``VCMDDAndroid``.

--- a/Help/variable/VC_MDD_ANDROID_VERSION.rst
+++ b/Help/variable/VC_MDD_ANDROID_VERSION.rst
@@ -1,0 +1,4 @@
+VC_MDD_ANDROID_VERSION
+-----------------------
+
+This variable is set to the value of ``CMAKE_SYSTEM_VERSION``.

--- a/Modules/CMakeDetermineCompilerId.cmake
+++ b/Modules/CMakeDetermineCompilerId.cmake
@@ -230,8 +230,19 @@ Id flags: ${testflags}
     endif()
     set(id_dir ${CMAKE_${lang}_COMPILER_ID_DIR})
     set(id_src "${src}")
-    configure_file(${CMAKE_ROOT}/Modules/CompilerId/VS-${v}.${ext}.in
-      ${id_dir}/CompilerId${lang}.${ext} @ONLY)
+    if(CMAKE_SYSTEM_NAME STREQUAL "VCMDDAndroid")
+      set(id_system "<ApplicationType>Android</ApplicationType>")
+      if(CMAKE_SYSTEM_VERSION)
+        set(id_system_version "<ApplicationTypeRevision>${CMAKE_SYSTEM_VERSION}</ApplicationTypeRevision>")
+      else()
+        set(id_system_version "<ApplicationTypeRevision>1.0</ApplicationTypeRevision>")
+      endif()
+      configure_file(${CMAKE_ROOT}/Modules/CompilerId/VS-Android.${ext}.in
+        ${id_dir}/CompilerId${lang}.${ext} @ONLY)
+    else()
+      configure_file(${CMAKE_ROOT}/Modules/CompilerId/VS-${v}.${ext}.in
+        ${id_dir}/CompilerId${lang}.${ext} @ONLY)
+    endif()
     if(CMAKE_VS_MSBUILD_COMMAND AND NOT lang STREQUAL "Fortran")
       set(command "${CMAKE_VS_MSBUILD_COMMAND}" "CompilerId${lang}.${ext}"
         "/p:Configuration=Debug" "/p:Platform=${id_platform}" "/p:VisualStudioVersion=${vs_version}.0"

--- a/Modules/CompilerId/VS-Android.vcxproj.in
+++ b/Modules/CompilerId/VS-Android.vcxproj.in
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">  
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|@id_platform@">
+      <Configuration>Debug</Configuration>
+      <Platform>@id_platform@</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{5d26626f-d955-4eba-b58e-3244446f46f3}</ProjectGuid>
+    <Keyword>Android</Keyword>
+    <RootNamespace>CompilerId@id_lang@</RootNamespace>
+    <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
+    @id_system@
+    @id_system_version@
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|@id_platform@'" Label="Configuration">
+    <!-- NOTE: we have to build a dynamic library as for a static library the executable format magic number is not at the beginning -->
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <!-- @id_toolset@ -->
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <PropertyGroup>
+    <_ProjectFileVersion>10.0.30319.1</_ProjectFileVersion>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|@id_platform@'">.\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Debug|@id_platform@'">$(Configuration)\</IntDir>
+    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Debug|@id_platform@'">false</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|@id_platform@'">
+    <ClCompile>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <MinimalRebuild>false</MinimalRebuild>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>TurnOffAllWarnings</WarningLevel>
+      <DebugInformationFormat>
+      </DebugInformationFormat>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>false</GenerateDebugInformation>
+      <SubSystem>Console</SubSystem>
+    </Link>
+    <PostBuildEvent>
+      <Command>
+        if "$(PlatformToolset)"=="Clang_3_4" (
+          @echo CMAKE_@id_lang@_COMPILER=$(LLVMToolchainPrebuiltRoot)\bin\clang.exe
+          goto :done
+        )
+        if "$(PlatformToolset)"=="Clang_3_6" (
+          @echo CMAKE_@id_lang@_COMPILER=$(LLVMToolchainPrebuiltRoot)\bin\clang.exe
+          goto :done
+        )
+        if "$(PlatformToolset)"=="Gcc_4_9" (
+          @echo CMAKE_@id_lang@_COMPILER=$(ToolchainPrebuiltPath)\bin\$(ToolchainPrefix)gcc.exe
+          goto :done
+        )
+        :done
+      </Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="@id_src@" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+</Project>

--- a/Modules/Platform/VCMDDAndroid.cmake
+++ b/Modules/Platform/VCMDDAndroid.cmake
@@ -1,0 +1,13 @@
+include(Platform/Linux)
+
+set(CMAKE_TRY_COMPILE_EXECUTABLE_SUFFIX ".so")
+set(CMAKE_TRY_COMPILE_EXECUTABLE_PREFIX "lib")
+set(CMAKE_TRY_COMPILE_OUTPUT_TYPE "shared")
+
+# Android has soname, but binary names must end in ".so" so we cannot append
+# a version number.  Also we cannot portably represent symlinks on the host.
+set(CMAKE_PLATFORM_NO_VERSIONED_SONAME 1)
+
+# Android reportedly ignores RPATH, and we cannot predict the install
+# location anyway.
+set(CMAKE_SHARED_LIBRARY_RUNTIME_C_FLAG "")

--- a/Source/cmCoreTryCompile.cxx
+++ b/Source/cmCoreTryCompile.cxx
@@ -490,8 +490,20 @@ int cmCoreTryCompile::TryCompileCode(std::vector<std::string> const& argv)
     /* Put the executable at a known location (for COPY_FILE).  */
     fprintf(fout, "set(CMAKE_RUNTIME_OUTPUT_DIRECTORY \"%s\")\n",
             this->BinaryDirectory.c_str());
-    /* Create the actual executable.  */
-    fprintf(fout, "add_executable(%s", targetName.c_str());
+    std::string outputType = this->Makefile->GetSafeDefinition(
+                                          "CMAKE_TRY_COMPILE_OUTPUT_TYPE");
+    if (outputType == "shared")
+      {
+      fprintf(fout, "add_library(%s SHARED ", targetName.c_str());
+      }
+    else if (outputType == "static")
+      {
+      fprintf(fout, "add_library(%s STATIC ", targetName.c_str());
+      }
+    else
+      {
+      fprintf(fout, "add_executable(%s", targetName.c_str());
+      }
     for(std::vector<std::string>::iterator si = sources.begin();
         si != sources.end(); ++si)
       {
@@ -657,8 +669,12 @@ void cmCoreTryCompile::FindOutputFile(const std::string& targetName)
   this->FindErrorMessage = "";
   this->OutputFile = "";
   std::string tmpOutputFile = "/";
+  tmpOutputFile +=this->Makefile->GetSafeDefinition(
+                                        "CMAKE_TRY_COMPILE_EXECUTABLE_PREFIX");
   tmpOutputFile += targetName;
   tmpOutputFile +=this->Makefile->GetSafeDefinition("CMAKE_EXECUTABLE_SUFFIX");
+  tmpOutputFile +=this->Makefile->GetSafeDefinition(
+                                        "CMAKE_TRY_COMPILE_EXECUTABLE_SUFFIX");
 
   // a list of directories where to search for the compilation result
   // at first directly in the binary dir

--- a/Source/cmGlobalVisualStudio10Generator.cxx
+++ b/Source/cmGlobalVisualStudio10Generator.cxx
@@ -101,6 +101,7 @@ cmGlobalVisualStudio10Generator::cmGlobalVisualStudio10Generator(cmake* cm,
   this->SystemIsWindowsCE = false;
   this->SystemIsWindowsPhone = false;
   this->SystemIsWindowsStore = false;
+  this->SystemIsAndroidMDD = false;
   this->MSBuildCommandInitialized = false;
   this->Version = VS10;
 }
@@ -207,6 +208,14 @@ bool cmGlobalVisualStudio10Generator::InitializeSystem(cmMakefile* mf)
       return false;
       }
     }
+  else if (this->SystemName == "VCMDDAndroid")
+    {
+    this->SystemIsAndroidMDD = true;
+    if(!this->InitializeAndroidMDD(mf))
+      {
+      return false;
+      }
+    }
   else if(this->SystemName == "Android")
     {
     if(this->DefaultPlatformName != "Win32")
@@ -274,6 +283,14 @@ bool cmGlobalVisualStudio10Generator::InitializeWindowsStore(cmMakefile* mf)
   e << this->GetName() << " does not support Windows Store.";
   mf->IssueMessage(cmake::FATAL_ERROR, e.str());
   return false;
+}
+
+bool cmGlobalVisualStudio10Generator::InitializeAndroidMDD(cmMakefile* mf)
+{
+    std::ostringstream e;
+    e << this->GetName() << " does not support Android MDD.";
+    mf->IssueMessage(cmake::FATAL_ERROR, e.str());
+    return false;
 }
 
 //----------------------------------------------------------------------------
@@ -640,4 +657,24 @@ std::string cmGlobalVisualStudio10Generator::GetInstalledNsightTegraVersion()
     "HKEY_LOCAL_MACHINE\\SOFTWARE\\NVIDIA Corporation\\Nsight Tegra;"
     "Version", version, cmSystemTools::KeyWOW64_32);
   return version;
+}
+
+const char* cmGlobalVisualStudio10Generator::GetAndroidMDDVersion()
+{
+  if (this->SystemVersion == "")
+    {
+    return "1.0";
+    }
+  return this->SystemVersion.c_str();
+}
+
+bool cmGlobalVisualStudio10Generator::IsAndroidMDDInstalled()
+{
+  std::string ideVersion = GetIDEVersion();
+  std::string installed;
+  cmSystemTools::ReadRegistryValue(
+    "HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\DevDiv\\MDD\\Servicing\\" +
+    ideVersion + "\\CPlusPlusCore;"
+    "Install", installed, cmSystemTools::KeyWOW64_32);
+  return installed == "1";
 }

--- a/Source/cmGlobalVisualStudio10Generator.h
+++ b/Source/cmGlobalVisualStudio10Generator.h
@@ -86,6 +86,10 @@ public:
   bool TargetsWindowsPhone() const
     { return this->SystemIsWindowsPhone; }
 
+  /** Return true if building for Android */
+  bool TargetsAndroidMDD() const
+    { return this->SystemIsAndroidMDD; }
+
   /** Return true if building for WindowsStore */
   bool TargetsWindowsStore() const
     { return this->SystemIsWindowsStore; }
@@ -106,6 +110,9 @@ public:
 
   static std::string GetInstalledNsightTegraVersion();
 
+  const char* GetAndroidMDDVersion();
+  bool IsAndroidMDDInstalled();
+
 protected:
   virtual void Generate();
   virtual bool InitializeSystem(cmMakefile* mf);
@@ -113,6 +120,7 @@ protected:
   virtual bool InitializeWindowsCE(cmMakefile* mf);
   virtual bool InitializeWindowsPhone(cmMakefile* mf);
   virtual bool InitializeWindowsStore(cmMakefile* mf);
+  virtual bool InitializeAndroidMDD(cmMakefile* mf);
 
   virtual std::string SelectWindowsCEToolset() const;
   virtual bool SelectWindowsPhoneToolset(std::string& toolset) const;
@@ -131,6 +139,7 @@ protected:
   bool SystemIsWindowsCE;
   bool SystemIsWindowsPhone;
   bool SystemIsWindowsStore;
+  bool SystemIsAndroidMDD;
   bool ExpressEdition;
 
   bool UseFolderProperty();

--- a/Source/cmGlobalVisualStudio14Generator.cxx
+++ b/Source/cmGlobalVisualStudio14Generator.cxx
@@ -289,3 +289,34 @@ std::string cmGlobalVisualStudio14Generator::GetWindows10SDKVersion()
   // Return an empty string
   return std::string();
 }
+//----------------------------------------------------------------------------
+bool cmGlobalVisualStudio14Generator::InitializeAndroidMDD(cmMakefile* mf)
+{
+  if(this->DefaultPlatformName != "Win32" &&
+     this->DefaultPlatformName != "ARM")
+    {
+    std::ostringstream e;
+    e << "Architecture not supported '" <<  this->DefaultPlatformName <<
+         "' for CMAKE_SYSTEM_NAME 'VCMDDAndroid'";
+    mf->IssueMessage(cmake::FATAL_ERROR, e.str());
+    return false;
+    }
+  if(!this->IsAndroidMDDInstalled())
+    {
+    mf->IssueMessage(cmake::FATAL_ERROR,
+        "CMAKE_SYSTEM_NAME is 'VCMDDAndroid' but "
+        "'Visual C++ for Mobile Development (Android support)' "
+        "is not installed.");
+    return false;
+    }
+  if(this->DefaultPlatformName == "Win32")
+    {
+    this->DefaultPlatformName = "x86";
+    this->DefaultPlatformToolset = "";
+    }
+  mf->AddDefinition("VC_MDD", true);
+  mf->AddDefinition("VC_MDD_ANDROID", true);
+  const char* v = this->GetAndroidMDDVersion();
+  mf->AddDefinition("VC_MDD_ANDROID_VERSION", v);
+  return true;
+}

--- a/Source/cmGlobalVisualStudio14Generator.h
+++ b/Source/cmGlobalVisualStudio14Generator.h
@@ -33,6 +33,7 @@ protected:
   virtual bool InitializeWindows(cmMakefile* mf);
   virtual bool InitializeWindowsStore(cmMakefile* mf);
   virtual bool SelectWindowsStoreToolset(std::string& toolset) const;
+  virtual bool InitializeAndroidMDD(cmMakefile* mf);
 
   // These aren't virtual because we need to check if the selected version
   // of the toolset is installed

--- a/Source/cmTarget.cxx
+++ b/Source/cmTarget.cxx
@@ -151,6 +151,7 @@ cmTarget::cmTarget()
   this->HaveInstallRule = false;
   this->DLLPlatform = false;
   this->IsAndroid = false;
+  this->AndroidMDD = false;
   this->IsApple = false;
   this->IsImportedTarget = false;
   this->BuildInterfaceIncludesAppended = false;
@@ -189,6 +190,10 @@ void cmTarget::SetMakefile(cmMakefile* mf)
   this->IsAndroid =
     strcmp(this->Makefile->GetSafeDefinition("CMAKE_SYSTEM_NAME"),
            "Android") == 0;
+
+  this->AndroidMDD =
+    strcmp(this->Makefile->GetSafeDefinition("CMAKE_SYSTEM_NAME"),
+           "VCMDDAndroid") == 0;
 
   // Check whether we are targeting an Apple platform.
   this->IsApple = this->Makefile->IsOn("APPLE");
@@ -250,6 +255,9 @@ void cmTarget::SetMakefile(cmMakefile* mf)
     this->SetPropertyDefault("CXX_EXTENSIONS", 0);
     this->SetPropertyDefault("LINK_SEARCH_START_STATIC", 0);
     this->SetPropertyDefault("LINK_SEARCH_END_STATIC", 0);
+    this->SetPropertyDefault("VC_MDD_ANDROID_USE_OF_STL", 0);
+    this->SetPropertyDefault("VC_MDD_ANDROID_API_LEVEL", 0);
+    this->SetPropertyDefault("VC_MDD_ANDROID_PLATFORM_TOOLSET", 0);
     }
 
   // Collect the set of configuration types.

--- a/Source/cmTarget.h
+++ b/Source/cmTarget.h
@@ -314,6 +314,9 @@ public:
   /** Return whether or not the target is for a DLL platform.  */
   bool IsDLLPlatform() const { return this->DLLPlatform; }
 
+  /** Return whether or not the target is for a DLL platform.  */
+  bool IsAndroidMDD() const { return this->AndroidMDD; }
+
   /** Return whether or not the target has a DLL import library.  */
   bool HasImportLibrary() const;
 
@@ -499,6 +502,7 @@ private:
   bool RecordDependencies;
   bool DLLPlatform;
   bool IsAndroid;
+  bool AndroidMDD;
   bool IsApple;
   bool IsImportedTarget;
   bool BuildInterfaceIncludesAppended;

--- a/Source/cmVisualStudio10TargetGenerator.h
+++ b/Source/cmVisualStudio10TargetGenerator.h
@@ -60,6 +60,7 @@ private:
   void WriteHeaderSource(cmSourceFile const* sf);
   void WriteExtraSource(cmSourceFile const* sf);
   void WriteNsightTegraConfigurationValues(std::string const& config);
+  void WriteAndroidMDDConfigurationValues(std::string const& config);
   void WriteSource(std::string const& tool, cmSourceFile const* sf,
                    const char* end = 0);
   void WriteSources(std::string const& tool,
@@ -157,6 +158,7 @@ private:
   bool MSTools;
   bool NsightTegra;
   int  NsightTegraVersion[4];
+  bool AndroidMDD;
   bool TargetCompileAsWinRT;
   cmGlobalVisualStudio10Generator* GlobalGenerator;
   cmGeneratedFileStream* BuildFileStream;

--- a/Source/kwsys/SystemTools.cxx
+++ b/Source/kwsys/SystemTools.cxx
@@ -1020,6 +1020,11 @@ bool SystemTools::ReadRegistryValue(const std::string& key, std::string &value,
           valueset = true;
           }
         }
+      else if (dwType == REG_DWORD)
+        {
+        value = std::to_string(*reinterpret_cast<DWORD*>(data));
+        valueset = true;
+        }
       }
 
     RegCloseKey(hKey);

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -2095,6 +2095,24 @@ ${CMake_BINARY_DIR}/bin/cmake -DDIR=dev -P ${CMake_SOURCE_DIR}/Utilities/Release
     endif()
   endif()
 
+  get_filename_component(reg_vcmdd_android_vs14 "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\DevDiv\\MDD\\Servicing\\14.0\\CPlusPlusCore;Install]" NAME)
+  if(reg_vcmdd_android_vs14 MATCHES 1)
+    macro(add_test_VCMDDAndroid name generator)
+      add_test(NAME VCMDDAndroid.${name} COMMAND ${CMAKE_CTEST_COMMAND}
+        --build-and-test
+        "${CMake_SOURCE_DIR}/Tests/VCMDDAndroid"
+        "${CMake_BINARY_DIR}/Tests/VCMDDAndroid/${name}"
+        --build-generator "${generator}"
+        --build-project VCMDDAndroid
+        --build-config $<CONFIGURATION>
+        --build-options -DCMAKE_SYSTEM_NAME=VCMDDAndroid
+        )
+      list(APPEND TEST_BUILD_DIRS "${CMake_BINARY_DIR}/Tests/VCMDDAndroid/${name}")
+    endmacro()
+    add_test_VCMDDAndroid(vs14 "Visual Studio 14")
+    add_test_VCMDDAndroid(vs14_arm "Visual Studio 14 ARM")
+  endif()
+
   if (APPLE)
     if (CMAKE_COMPILER_IS_GNUCXX OR "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
       set(BundleTestInstallDir

--- a/Tests/VCMDDAndroid/CMakeLists.txt
+++ b/Tests/VCMDDAndroid/CMakeLists.txt
@@ -1,0 +1,6 @@
+cmake_minimum_required (VERSION 3.3.2)
+project (VCMDDAndroid)
+add_library(libA OBJECT source1.cpp)
+add_library(libB SHARED $<TARGET_OBJECTS:libA> source2.cpp)
+set_property(TARGET libB PROPERTY VC_MDD_ANDROID_USE_OF_STL "c++_static")
+set_property(TARGET libB PROPERTY VC_MDD_ANDROID_API_LEVEL "android-21")

--- a/Tests/VCMDDAndroid/source1.cpp
+++ b/Tests/VCMDDAndroid/source1.cpp
@@ -1,0 +1,5 @@
+int foo()
+{
+    int a = 1;
+    return a;
+}

--- a/Tests/VCMDDAndroid/source2.cpp
+++ b/Tests/VCMDDAndroid/source2.cpp
@@ -1,0 +1,5 @@
+int foo();
+int bar()
+{
+    return foo();
+}


### PR DESCRIPTION
Support Visual C++ for Mobile Development targeting Android. This allows CMake to target the Visual Studio projects that support Android development.

Use cmake -G "Visual Studio 14" -DCMAKE_SYSTEM_NAME=VCMDDAndroid to use it. No other configurations are required, aside VC tooling from Android, that can be installed thru Visual Studio Setup.

Additionally, added a property in the generated projects to identify CMake generated projects.  
