### PR TITLE
CMake server - fix install path

### DIFF
--- a/Source/cmInstallCommand.cxx
+++ b/Source/cmInstallCommand.cxx
@@ -36,7 +36,6 @@ static cmInstallTargetGenerator* CreateInstallTargetGenerator(
   cmInstallGenerator::MessageLevel message =
     cmInstallGenerator::SelectMessageLevel(target.GetMakefile());
   target.SetHaveInstallRule(true);
-  target.SetInstallPath(args.GetDestination().c_str());
   return new cmInstallTargetGenerator(
     target.GetName(), args.GetDestination().c_str(), impLib,
     args.GetPermissions().c_str(), args.GetConfigurations(),

--- a/Source/cmInstallCommand.cxx
+++ b/Source/cmInstallCommand.cxx
@@ -36,6 +36,7 @@ static cmInstallTargetGenerator* CreateInstallTargetGenerator(
   cmInstallGenerator::MessageLevel message =
     cmInstallGenerator::SelectMessageLevel(target.GetMakefile());
   target.SetHaveInstallRule(true);
+  target.SetInstallPath(args.GetDestination().c_str());
   return new cmInstallTargetGenerator(
     target.GetName(), args.GetDestination().c_str(), impLib,
     args.GetPermissions().c_str(), args.GetConfigurations(),

--- a/Source/cmServerProtocol.cxx
+++ b/Source/cmServerProtocol.cxx
@@ -7,6 +7,7 @@
 #include "cmGeneratorExpression.h"
 #include "cmGeneratorTarget.h"
 #include "cmGlobalGenerator.h"
+#include "cmInstallTargetGenerator.h"
 #include "cmLinkLineComputer.h"
 #include "cmLocalGenerator.h"
 #include "cmMakefile.h"
@@ -808,12 +809,28 @@ static Json::Value DumpTarget(cmGeneratorTarget* target,
 
   if (target->Target->GetHaveInstallRule()) {
     result[kHAS_INSTALL_RULE] = true;
-    std::string installPrefix = target->Makefile->GetSafeDefinition("CMAKE_INSTALL_PREFIX");
-    if (!installPrefix.empty()) {
-      result[kINSTALL_PATH] = installPrefix + '/' + target->Target->GetInstallPath();
-    }
-    else {
-      result[kINSTALL_PATH] = target->Target->GetInstallPath();
+
+    auto targetGenerators = target->Makefile->GetInstallGenerators();
+    for (auto iter = targetGenerators.begin(); iter != targetGenerators.end(); iter++)
+    {
+      auto installTargetGenerator = dynamic_cast<cmInstallTargetGenerator*>(*iter);
+      if (installTargetGenerator != nullptr &&
+        installTargetGenerator->GetTarget()->Target == target->Target) {
+        auto dest = installTargetGenerator->GetDestination(config);
+        
+        std::string installPath;
+        if (!dest.empty() && cmSystemTools::FileIsFullPath(dest.c_str()))
+        {
+          installPath = dest;
+        }
+        else
+        {
+          std::string installPrefix = target->Makefile->GetSafeDefinition("CMAKE_INSTALL_PREFIX");
+          installPath = installPrefix + '/' + dest;
+        }
+        
+        result[kINSTALL_PATH] = installPath;
+      }
     }
   } else {
     result[kHAS_INSTALL_RULE] = false;


### PR DESCRIPTION
We now mimic the logic used in generating the install path in the install script. This allows cmake server requests to return the correct install path.