### PR TITLE
Add support for diagnostics for the VS 2017 generator

### DIFF
--- a/Source/cmVS141CLFlagTable.h
+++ b/Source/cmVS141CLFlagTable.h
@@ -1,6 +1,10 @@
 static cmVS7FlagTable cmVS141CLFlagTable[] = {
 
   // Enum Properties
+  { "DiagnosticsFormat", "diagnostics:classic", "Classic", "Classic", 0 },
+  { "DiagnosticsFormat", "diagnostics:column", "Column", "Column", 0 },
+  { "DiagnosticsFormat", "diagnostics:caret", "Caret", "Caret", 0 },
+
   { "DebugInformationFormat", "", "None", "None", 0 },
   { "DebugInformationFormat", "Z7", "C7 compatible", "OldStyle", 0 },
   { "DebugInformationFormat", "Zi", "Program Database", "ProgramDatabase", 0 },

--- a/Source/cmakemain.cxx
+++ b/Source/cmakemain.cxx
@@ -161,6 +161,9 @@ static void cmakemainProgressCallback(const char* m, float prog,
 int main(int ac, char const* const* av)
 {
 #if defined(_WIN32) && !defined(__CYGWIN__)
+  // Debugging aid. This allows us to set up a registry 
+  // key indicating a sleep period when the process starts,
+  // giving us enough time to attach the debugger.
   std::string sleepval;
   if (cmSystemTools::ReadRegistryValue(
     "HKEY_CURRENT_USER\\SOFTWARE\\Microsoft\\"

--- a/Source/cmakemain.cxx
+++ b/Source/cmakemain.cxx
@@ -160,6 +160,18 @@ static void cmakemainProgressCallback(const char* m, float prog,
 
 int main(int ac, char const* const* av)
 {
+#if defined(_WIN32) && !defined(__CYGWIN__)
+  std::string sleepval;
+  if (cmSystemTools::ReadRegistryValue(
+    "HKEY_CURRENT_USER\\SOFTWARE\\Microsoft\\"
+    "VCCMake;Sleep",
+    sleepval, cmSystemTools::KeyWOW64_32))
+  {
+    int sleepinMS = atoi(sleepval.c_str());
+    Sleep(sleepinMS);
+  }
+#endif
+
 #if defined(_WIN32) && defined(CMAKE_BUILD_WITH_CMAKE)
   // Replace streambuf so we can output Unicode to console
   cmsys::ConsoleBuf::Manager consoleOut(std::cout);


### PR DESCRIPTION
Add support for the new /diagnostics compiler flag. We now support setting that flag in CMAKE_CXX_FLAGS