### PR TITLE
cmake-server codemodel returns hasInstallRule at the project level

### DIFF
--- a/Source/cmServerProtocol.cxx
+++ b/Source/cmServerProtocol.cxx
@@ -264,7 +264,7 @@ bool cmServerProtocol::DoActivate(const cmServerRequest& /*request*/,
 
 std::pair<int, int> cmServerProtocol1::ProtocolVersion() const
 {
-  return std::make_pair(1, 1);
+  return std::make_pair(1, 2);
 }
 
 static void setErrorMessage(std::string* errorMessage, const std::string& text)
@@ -1135,6 +1135,7 @@ static Json::Value DumpProjectList(const cmake* cm, std::string const& config)
 
     // Project structure information:
     const cmMakefile* mf = lg->GetMakefile();
+	pObj[kHAS_INSTALL_RULE] = ((cmMakefile*)mf)->GetInstallGenerators().empty() == false;
     pObj[kSOURCE_DIRECTORY_KEY] = mf->GetCurrentSourceDirectory();
     pObj[kBUILD_DIRECTORY_KEY] = mf->GetCurrentBinaryDirectory();
     pObj[kTARGETS_KEY] = DumpTargetsList(projectIt.second, config);


### PR DESCRIPTION
hasInstallRule is true if the project has any install rules. cmake-server also returns hasInstallRule for each target. But we need the property at the project level as well because a project might have other types of install rules, "install(TARGET ...)" is only one type of install rule a project might have.