### PR TITLE
Split the build number into two version components

### DIFF
--- a/Source/CMakeVersion.rc.in
+++ b/Source/CMakeVersion.rc.in
@@ -1,13 +1,14 @@
 /* Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
    file Copyright.txt or https://cmake.org/licensing for details.  */
 
-#include <winres.h>
+#define VER_FILEVERSION             @CMake_RCVERSION@
+#define VER_FILEVERSION_STR         "@CMake_RCVERSION_STR@\0"
 
-#define VER_FILEVERSION             @CMake_VERSION_MAJOR@,@CMake_VERSION_MINOR@,@CMake_VERSION_PATCH@
-#define VER_FILEVERSION_STR         "@CMake_VERSION_MAJOR@.@CMake_VERSION_MINOR@.@CMake_VERSION_PATCH@\0"
+#define VER_PRODUCTVERSION          @CMake_RCVERSION@
+#define VER_PRODUCTVERSION_STR      "@CMake_RCVERSION_STR@\0"
 
-#define VER_PRODUCTVERSION          @CMake_VERSION_MAJOR@,@CMake_VERSION_MINOR@,@CMake_VERSION_PATCH@
-#define VER_PRODUCTVERSION_STR      "@CMake_VERSION@\0"
+/* Version-information resource identifier.  */
+#define VS_VERSION_INFO 1
 
 VS_VERSION_INFO VERSIONINFO
 FILEVERSION    	VER_FILEVERSION

--- a/Source/CMakeVersionCompute.cmake
+++ b/Source/CMakeVersionCompute.cmake
@@ -8,5 +8,13 @@ if(Microsoft_CMake_VERSION_PATCH)
   set(CMake_VERSION_PATCH ${Microsoft_CMake_VERSION_PATCH})
 endif()
 
-# Compute the full version string.
-set(CMake_VERSION ${CMake_VERSION_MAJOR}.${CMake_VERSION_MINOR}.${CMake_VERSION_PATCH}-MSVC_2)
+# Split the patch component because each version component in the RC file is a 16-bit integer.
+# Our patch version is of the form yymmddbb so we just split it in half.
+string(SUBSTRING ${CMake_VERSION_PATCH} 4 -1 CMake_VERSION_REV)
+string(SUBSTRING ${CMake_VERSION_PATCH} 0 4 CMake_VERSION_PATCH)
+
+# The '8' is an identifier to indicate it comes from our Microsoft/CMake fork.
+set(CMake_RCVERSION ${CMake_VERSION_MAJOR},${CMake_VERSION_MINOR},${CMake_VERSION_PATCH},${CMake_VERSION_REV}8)
+set(CMake_RCVERSION_STR ${CMake_VERSION_MAJOR}.${CMake_VERSION_MINOR}.${CMake_VERSION_PATCH}.${CMake_VERSION_REV}8)
+
+set(CMake_VERSION ${CMake_RCVERSION_STR})


### PR DESCRIPTION
Windows RC files can have 4 version components where each component is a
16-bit integer. So we go with the following format for our version
numbers where "8" is an indicator that the build came from our fork:
major.minor.yymm.ddbb8