### PR TITLE
Fix versioning

### DIFF
--- a/Source/CMakeVersionCompute.cmake
+++ b/Source/CMakeVersionCompute.cmake
@@ -8,13 +8,15 @@ if(Microsoft_CMake_VERSION_PATCH)
   set(CMake_VERSION_PATCH ${Microsoft_CMake_VERSION_PATCH})
 endif()
 
-# Split the patch component because each version component in the RC file is a 16-bit integer.
-# Our patch version is of the form yymmddbb so we just split it in half.
-string(SUBSTRING ${CMake_VERSION_PATCH} 4 -1 CMake_VERSION_REV)
-string(SUBSTRING ${CMake_VERSION_PATCH} 0 4 CMake_VERSION_PATCH)
+# Compute the full version string.
+set(CMake_VERSION ${CMake_VERSION_MAJOR}.${CMake_VERSION_MINOR}.${CMake_VERSION_PATCH}-MSVC_2)
 
-# The '8' is an identifier to indicate it comes from our Microsoft/CMake fork.
-set(CMake_RCVERSION ${CMake_VERSION_MAJOR},${CMake_VERSION_MINOR},${CMake_VERSION_PATCH},${CMake_VERSION_REV}8)
-set(CMake_RCVERSION_STR ${CMake_VERSION_MAJOR}.${CMake_VERSION_MINOR}.${CMake_VERSION_PATCH}.${CMake_VERSION_REV}8)
+# Compute the binary version that goes into the RC file. Each component of the RC version is 
+# a 16-bit integer. Our patch version is of the form yymmddbb so we just split it in half.
+string(SUBSTRING ${CMake_VERSION_PATCH} 0 4 CMake_RCVERSION_PATCH)
+string(SUBSTRING ${CMake_VERSION_PATCH} 4 -1 CMake_RCVERSION_REV)
 
-set(CMake_VERSION ${CMake_RCVERSION_STR})
+# The '8' is an identifier to indicate it comes from our Microsoft/CMake fork. It gets appended 
+# at the end to ensure the revision component is still a 16-bit number.
+set(CMake_RCVERSION ${CMake_VERSION_MAJOR},${CMake_VERSION_MINOR},${CMake_RCVERSION_PATCH},${CMake_RCVERSION_REV}8)
+set(CMake_RCVERSION_STR ${CMake_VERSION})

--- a/Source/CMakeVersionCompute.cmake
+++ b/Source/CMakeVersionCompute.cmake
@@ -11,8 +11,21 @@ endif()
 # Compute the full version string.
 set(CMake_VERSION ${CMake_VERSION_MAJOR}.${CMake_VERSION_MINOR}.${CMake_VERSION_PATCH}-MSVC_2)
 
-# Compute the binary version that goes into the RC file. Each component of the RC version is 
-# a 16-bit integer. Our patch version is of the form yymmddbb so we just split it in half.
+# Compute the binary version that goes into the RC file.
+# CMake version has the format major.minor.patch[-suffix] but for RC files
+# we need to split patch into two components because each component is a
+# 16-bit integer. Our patch numbers have the format yymmddbb so we split
+# that in half and append an "8" to identify a build coming from our branch.
+#
+# Example for build 02 generated on 12/1/2017
+# cmake version 3.10.17120102-MSVC_2
+# binary version that appears in file properties 3.10.1712.01028
+#
+# The reason we need consistency is for Watson crash dumps. It will report
+# the binary file version and we need to match it to our build.
+
+# Each component of the RC version is a 16-bit integer. Our patch version
+# is of the form yymmddbb so we just split it in half.
 string(SUBSTRING ${CMake_VERSION_PATCH} 0 4 CMake_RCVERSION_PATCH)
 string(SUBSTRING ${CMake_VERSION_PATCH} 4 -1 CMake_RCVERSION_REV)
 


### PR DESCRIPTION
The version has the format major.minor.patch[-suffix] but for RC files
we need to split patch into two components because each component is a
16-bit integer. Our patch numbers have the format yymmddbb so we split
that in half and append an "8" to identify a build coming from our
branch.

Example for build 02 generated on 12/1/2017
cmake version 3.10.17120102-MSVC_2
binary version that appears in file properties 3.10.1712.01028