### PR TITLE
Dev/rchiodo/add target dependencies

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,4 @@
+root = true
+[*]
+end_of_line = lf
+insert_final_newline = true

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,4 @@
 root = true
 [*]
-end_of_line = lf
+end_of_line = crlf
 insert_final_newline = true

--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -336,6 +336,8 @@ set(SRCS
   cmStateSnapshot.cxx
   cmStateSnapshot.h
   cmStateTypes.h
+  cmStringTable.cxx
+  cmStringTable.h
   cmSystemTools.cxx
   cmSystemTools.h
   cmTarget.cxx

--- a/Source/cmAddExecutableCommand.cxx
+++ b/Source/cmAddExecutableCommand.cxx
@@ -166,10 +166,10 @@ bool cmAddExecutableCommand::InitialPass(std::vector<std::string> const& args,
   cmTarget* tgt =
     this->Makefile->AddExecutable(exename.c_str(), srclists, excludeFromAll);
   if (use_win32) {
-    tgt->SetProperty("WIN32_EXECUTABLE", "ON");
+    tgt->SetProperty("WIN32_EXECUTABLE", "ON", tgt->GetBacktrace());
   }
   if (use_macbundle) {
-    tgt->SetProperty("MACOSX_BUNDLE", "ON");
+    tgt->SetProperty("MACOSX_BUNDLE", "ON", tgt->GetBacktrace());
   }
 
   return true;

--- a/Source/cmCPluginAPI.cxx
+++ b/Source/cmCPluginAPI.cxx
@@ -185,7 +185,7 @@ void CCONV cmAddExecutable(void* arg, const char* exename, int numSrcs,
   }
   cmTarget* tg = mf->AddExecutable(exename, srcs2);
   if (win32) {
-    tg->SetProperty("WIN32_EXECUTABLE", "ON");
+    tg->SetProperty("WIN32_EXECUTABLE", "ON", tg->GetBacktrace());
   }
 }
 
@@ -618,7 +618,7 @@ void CCONV cmSourceFileSetProperty(void* arg, const char* prop,
     if (!value) {
       value = "NOTFOUND";
     }
-    sf->Properties.SetProperty(prop, value);
+    sf->Properties.SetProperty(prop, value, cmListFileBacktrace::Empty());
   }
 }
 
@@ -737,7 +737,7 @@ void CCONV cmSourceFileSetName2(void* arg, const char* name, const char* dir,
 
   // Implement the old SetName method code here.
   if (headerFileOnly) {
-    sf->Properties.SetProperty("HEADER_FILE_ONLY", "1");
+    sf->Properties.SetProperty("HEADER_FILE_ONLY", "1", cmListFileBacktrace::Empty());
   }
   sf->SourceName = name;
   std::string fname = sf->SourceName;

--- a/Source/cmCPluginAPI.cxx
+++ b/Source/cmCPluginAPI.cxx
@@ -365,7 +365,7 @@ static void addLinkLibrary(cmMakefile* mf, std::string const& target,
     mf->IssueMessage(cmake::FATAL_ERROR, e.str());
   }
 
-  t->AddLinkLibrary(*mf, lib, llt);
+  t->AddLinkLibrary(*mf, lib, llt, mf->GetBacktrace());
 }
 
 void CCONV cmAddLinkLibraryForTarget(void* arg, const char* tgt,

--- a/Source/cmCacheManager.cxx
+++ b/Source/cmCacheManager.cxx
@@ -577,7 +577,7 @@ void cmCacheManager::CacheEntry::SetProperty(const std::string& prop,
   } else if (prop == "VALUE") {
     this->Value = value ? value : "";
   } else {
-    this->Properties.SetProperty(prop, value);
+    this->Properties.SetProperty(prop, value, cmListFileBacktrace::Empty());
   }
 }
 
@@ -595,7 +595,7 @@ void cmCacheManager::CacheEntry::AppendProperty(const std::string& prop,
       this->Value += value;
     }
   } else {
-    this->Properties.AppendProperty(prop, value, asString);
+    this->Properties.AppendProperty(prop, value, cmListFileBacktrace::Empty(), asString);
   }
 }
 

--- a/Source/cmCommand.h
+++ b/Source/cmCommand.h
@@ -4,6 +4,7 @@
 #define cmCommand_h
 
 #include "cmConfigure.h" // IWYU pragma: keep
+#include "cmListFileCache.h"
 
 #include <string>
 #include <vector>
@@ -45,6 +46,12 @@ public:
    */
   void SetMakefile(cmMakefile* m) { this->Makefile = m; }
   cmMakefile* GetMakefile() { return this->Makefile; }
+
+  /**
+   * Save the backtrace for the creation of the command
+   */
+  void SetBacktrace(const cmListFileBacktrace & bt) { this->backTrace = bt; }
+  const cmListFileBacktrace & GetBacktrace() const { return this->backTrace; }
 
   /**
    * This is called by the cmMakefile when the command is first
@@ -91,6 +98,7 @@ public:
 
 protected:
   cmMakefile* Makefile;
+  cmListFileBacktrace backTrace;
 
 private:
   std::string Error;

--- a/Source/cmComputeComponentGraph.cxx
+++ b/Source/cmComputeComponentGraph.cxx
@@ -126,7 +126,7 @@ void cmComputeComponentGraph::TransferEdges()
         // We do not attempt to combine duplicate edges, but instead
         // store the inter-component edges with suitable multiplicity.
         this->ComponentGraph[i_component].push_back(
-          cmGraphEdge(j_component, ni.IsStrong()));
+          cmGraphEdge(j_component, ni.IsStrong(), &ni.Backtrace()));
       }
     }
   }

--- a/Source/cmComputeLinkDepends.cxx
+++ b/Source/cmComputeLinkDepends.cxx
@@ -417,7 +417,7 @@ void cmComputeLinkDepends::HandleSharedDependency(SharedDepEntry const& dep)
 
   // This shared library dependency must follow the item that listed
   // it.
-  this->EntryConstraintGraph[dep.DependerIndex].push_back(index);
+  this->EntryConstraintGraph[dep.DependerIndex].push_back(cmGraphEdge(index, false, nullptr));
 
   // Target items may have their own dependencies.
   if (entry.Target) {
@@ -521,7 +521,7 @@ void cmComputeLinkDepends::AddLinkEntries(int depender_index,
 
     // The dependee must come after the depender.
     if (depender_index >= 0) {
-      this->EntryConstraintGraph[depender_index].push_back(dependee_index);
+      this->EntryConstraintGraph[depender_index].push_back(cmGraphEdge(dependee_index, false, &item.Backtrace));
     } else {
       // This is a direct dependency of the target being linked.
       this->OriginalEntries.push_back(dependee_index);
@@ -593,7 +593,9 @@ void cmComputeLinkDepends::InferDependencies()
 
     // Add the inferred dependencies to the graph.
     cmGraphEdgeList& edges = this->EntryConstraintGraph[depender_index];
-    edges.insert(edges.end(), common.begin(), common.end());
+    for (const auto & c : common) {
+        edges.push_back(cmGraphEdge(c, false, nullptr));
+    }
   }
 }
 

--- a/Source/cmComputeLinkInformation.cxx
+++ b/Source/cmComputeLinkInformation.cxx
@@ -1096,7 +1096,7 @@ bool cmComputeLinkInformation::CheckImplicitDirItem(std::string const& item)
         // Print the warning at most once for this item.
         std::string const& wid = "CMP0060-WARNING-GIVEN-" + item;
         if (!this->CMakeInstance->GetPropertyAsBool(wid)) {
-          this->CMakeInstance->SetProperty(wid, "1");
+          this->CMakeInstance->SetProperty(wid, "1", this->Target->GetBacktrace());
           this->CMP0060WarnItems.insert(item);
         }
       }
@@ -1374,7 +1374,7 @@ void cmComputeLinkInformation::HandleBadFullItem(std::string const& item,
       std::string wid = "CMP0008-WARNING-GIVEN-";
       wid += item;
       if (!this->CMakeInstance->GetState()->GetGlobalPropertyAsBool(wid)) {
-        this->CMakeInstance->GetState()->SetGlobalProperty(wid, "1");
+        this->CMakeInstance->GetState()->SetGlobalProperty(wid, "1", this->Target->GetBacktrace());
         std::ostringstream w;
         /* clang-format off */
         w << cmPolicies::GetPolicyWarning(cmPolicies::CMP0008) << "\n"
@@ -1421,7 +1421,7 @@ bool cmComputeLinkInformation::FinishLinkerSearchDirectories()
       if (!this->CMakeInstance->GetState()->GetGlobalPropertyAsBool(
             "CMP0003-WARNING-GIVEN")) {
         this->CMakeInstance->GetState()->SetGlobalProperty(
-          "CMP0003-WARNING-GIVEN", "1");
+          "CMP0003-WARNING-GIVEN", "1", this->Target->GetBacktrace());
         std::ostringstream w;
         this->PrintLinkPolicyDiagnosis(w);
         this->CMakeInstance->IssueMessage(cmake::AUTHOR_WARNING, w.str(),

--- a/Source/cmComputeTargetDepends.h
+++ b/Source/cmComputeTargetDepends.h
@@ -47,7 +47,7 @@ private:
   void AddTargetDepend(int depender_index, cmLinkItem const& dependee_name,
                        bool linking);
   void AddTargetDepend(int depender_index, cmGeneratorTarget const* dependee,
-                       bool linking);
+                       bool linking, cmListFileBacktrace const & dependee_backtrace);
   bool ComputeFinalDepends(cmComputeComponentGraph const& ccg);
   void AddInterfaceDepends(int depender_index, cmLinkItem const& dependee_name,
                            const std::string& config,

--- a/Source/cmExportInstallAndroidMKGenerator.cxx
+++ b/Source/cmExportInstallAndroidMKGenerator.cxx
@@ -40,13 +40,16 @@ void cmExportInstallAndroidMKGenerator::GenerateImportHeaderCode(
       continue;
     }
     std::string dest;
+    cmListFileBacktrace backtrace;
     if (te->LibraryGenerator) {
       dest = te->LibraryGenerator->GetDestination("");
+      backtrace = te->LibraryGenerator->GetTarget()->GetBacktrace();
     }
     if (te->ArchiveGenerator) {
       dest = te->ArchiveGenerator->GetDestination("");
+      backtrace = te->ArchiveGenerator->GetTarget()->GetBacktrace();
     }
-    te->Target->Target->SetProperty("__dest", dest.c_str());
+    te->Target->Target->SetProperty("__dest", dest.c_str(), backtrace);
   }
 }
 

--- a/Source/cmFindPackageCommand.cxx
+++ b/Source/cmFindPackageCommand.cxx
@@ -1019,11 +1019,11 @@ void cmFindPackageCommand::AppendToFoundProperty(bool found)
   }
 
   std::string tmp = cmJoin(foundContents, ";");
-  this->Makefile->GetState()->SetGlobalProperty("PACKAGES_FOUND", tmp.c_str());
+  this->Makefile->GetState()->SetGlobalProperty("PACKAGES_FOUND", tmp.c_str(), this->Makefile->GetBacktrace());
 
   tmp = cmJoin(notFoundContents, ";");
   this->Makefile->GetState()->SetGlobalProperty("PACKAGES_NOT_FOUND",
-                                                tmp.c_str());
+                                                tmp.c_str(), this->Makefile->GetBacktrace());
 }
 
 void cmFindPackageCommand::AppendSuccessInformation()
@@ -1031,7 +1031,7 @@ void cmFindPackageCommand::AppendSuccessInformation()
   {
     std::string transitivePropName = "_CMAKE_";
     transitivePropName += this->Name + "_TRANSITIVE_DEPENDENCY";
-    this->Makefile->GetState()->SetGlobalProperty(transitivePropName, "False");
+    this->Makefile->GetState()->SetGlobalProperty(transitivePropName, "False", this->Makefile->GetBacktrace());
   }
   std::string found = this->Name;
   found += "_FOUND";
@@ -1050,7 +1050,7 @@ void cmFindPackageCommand::AppendSuccessInformation()
   quietInfoPropName += this->Name;
   quietInfoPropName += "_QUIET";
   this->Makefile->GetState()->SetGlobalProperty(
-    quietInfoPropName, this->Quiet ? "TRUE" : "FALSE");
+    quietInfoPropName, this->Quiet ? "TRUE" : "FALSE", this->Makefile->GetBacktrace());
 
   // set a global property to record the required version of this package
   std::string versionInfoPropName = "_CMAKE_";
@@ -1063,13 +1063,13 @@ void cmFindPackageCommand::AppendSuccessInformation()
     versionInfo += this->Version;
   }
   this->Makefile->GetState()->SetGlobalProperty(versionInfoPropName,
-                                                versionInfo.c_str());
+                                                versionInfo.c_str(), this->Makefile->GetBacktrace());
   if (this->Required) {
     std::string requiredInfoPropName = "_CMAKE_";
     requiredInfoPropName += this->Name;
     requiredInfoPropName += "_TYPE";
     this->Makefile->GetState()->SetGlobalProperty(requiredInfoPropName,
-                                                  "REQUIRED");
+                                                  "REQUIRED", this->Makefile->GetBacktrace());
   }
 
   // Restore original state of "_FIND_" variables we set.

--- a/Source/cmFunctionCommand.cxx
+++ b/Source/cmFunctionCommand.cxx
@@ -137,7 +137,7 @@ bool cmFunctionFunctionBlocker::IsFunctionBlocked(
       cmFunctionHelperCommand* f = new cmFunctionHelperCommand();
       f->Args = this->Args;
       f->Functions = this->Functions;
-      f->FilePath = this->GetStartingContext().FilePath;
+      f->FilePath = this->GetStartingContext().FilePath();
       mf.RecordPolicies(f->Policies);
       mf.GetState()->AddScriptedCommand(this->Args[0], f);
       // remove the function blocker now that the function is defined
@@ -160,7 +160,7 @@ bool cmFunctionFunctionBlocker::ShouldRemove(const cmListFileFunction& lff,
   if (!cmSystemTools::Strucmp(lff.Name.c_str(), "endfunction")) {
     std::vector<std::string> expandedArguments;
     mf.ExpandArguments(lff.Arguments, expandedArguments,
-                       this->GetStartingContext().FilePath.c_str());
+                       this->GetStartingContext().FilePath().c_str());
     // if the endfunction has arguments then make sure
     // they match the ones in the opening function command
     if ((expandedArguments.empty() ||

--- a/Source/cmGlobalGenerator.cxx
+++ b/Source/cmGlobalGenerator.cxx
@@ -239,7 +239,7 @@ void cmGlobalGenerator::ResolveLanguageCompiler(const std::string& lang,
       changeVars += ";";
       changeVars += cname;
       this->GetCMakeInstance()->GetState()->SetGlobalProperty(
-        "__CMAKE_DELETE_CACHE_CHANGE_VARS_", changeVars.c_str());
+        "__CMAKE_DELETE_CACHE_CHANGE_VARS_", changeVars.c_str(), cmListFileBacktrace::Empty());
     }
   }
 }
@@ -1574,7 +1574,7 @@ void cmGlobalGenerator::FinalizeTargetCompileInfo()
         for (std::string const& c : configs) {
           std::string defPropName = "COMPILE_DEFINITIONS_";
           defPropName += cmSystemTools::UpperCase(c);
-          t->AppendProperty(defPropName, mf->GetProperty(defPropName));
+          t->AppendProperty(defPropName, mf->GetProperty(defPropName), t->GetPropertyBacktrace(defPropName));
         }
       }
     }
@@ -2568,7 +2568,7 @@ cmTarget cmGlobalGenerator::CreateGlobalTarget(GlobalTargetInfo const& gti,
   // Package
   cmTarget target(gti.Name, cmStateEnums::GLOBAL_TARGET,
                   cmTarget::VisibilityNormal, mf);
-  target.SetProperty("EXCLUDE_FROM_ALL", "TRUE");
+  target.SetProperty("EXCLUDE_FROM_ALL", "TRUE", target.GetBacktrace());
 
   std::vector<std::string> no_outputs;
   std::vector<std::string> no_byproducts;
@@ -2579,7 +2579,7 @@ cmTarget cmGlobalGenerator::CreateGlobalTarget(GlobalTargetInfo const& gti,
   cc.SetUsesTerminal(gti.UsesTerminal);
   target.AddPostBuildCommand(cc);
   if (!gti.Message.empty()) {
-    target.SetProperty("EchoString", gti.Message.c_str());
+    target.SetProperty("EchoString", gti.Message.c_str(), target.GetBacktrace());
   }
   for (std::string const& d : gti.Depends) {
     target.AddUtility(d);
@@ -2588,7 +2588,7 @@ cmTarget cmGlobalGenerator::CreateGlobalTarget(GlobalTargetInfo const& gti,
   // Organize in the "predefined targets" folder:
   //
   if (this->UseFolderProperty()) {
-    target.SetProperty("FOLDER", this->GetPredefinedTargetsFolder());
+    target.SetProperty("FOLDER", this->GetPredefinedTargetsFolder(), target.GetBacktrace());
   }
 
   return target;

--- a/Source/cmGlobalVisualStudio8Generator.cxx
+++ b/Source/cmGlobalVisualStudio8Generator.cxx
@@ -235,7 +235,7 @@ bool cmGlobalVisualStudio8Generator::AddCheckTarget()
   // Organize in the "predefined targets" folder:
   //
   if (this->UseFolderProperty()) {
-    tgt->SetProperty("FOLDER", this->GetPredefinedTargetsFolder());
+    tgt->SetProperty("FOLDER", this->GetPredefinedTargetsFolder(), tgt->GetBacktrace());
   }
 
   // Create a list of all stamp files for this project.

--- a/Source/cmGlobalVisualStudioGenerator.cxx
+++ b/Source/cmGlobalVisualStudioGenerator.cxx
@@ -79,7 +79,7 @@ void cmGlobalVisualStudioGenerator::AddExtraIDETargets()
       // Organize in the "predefined targets" folder:
       //
       if (this->UseFolderProperty()) {
-        allBuild->SetProperty("FOLDER", this->GetPredefinedTargetsFolder());
+        allBuild->SetProperty("FOLDER", this->GetPredefinedTargetsFolder(), gt->Target->GetBacktrace());
       }
 
       // Now make all targets depend on the ALL_BUILD target

--- a/Source/cmGraphAdjacencyList.h
+++ b/Source/cmGraphAdjacencyList.h
@@ -4,6 +4,7 @@
 #define cmGraphAdjacencyList_h
 
 #include "cmConfigure.h" // IWYU pragma: keep
+#include "cmListFileCache.h"
 
 #include <vector>
 
@@ -15,17 +16,42 @@
 class cmGraphEdge
 {
 public:
-  cmGraphEdge(int n = 0, bool s = true)
+  cmGraphEdge(int n, bool s, cmListFileBacktrace const * pbt)
     : Dest(n)
     , Strong(s)
+    , backtrace()
   {
+    if (pbt != nullptr) {
+      backtrace = *pbt;
+    }
   }
+
+  // Graph edges may be copied and assigned as values. (Move semantics not supported on all platforms?)
+  cmGraphEdge(cmGraphEdge const& r)
+     : Dest(r.Dest)
+     , Strong(r.Strong)
+     , backtrace(r.backtrace)
+  {
+     
+  }
+  cmGraphEdge& operator=(cmGraphEdge const& r)
+  {
+      this->Dest = r.Dest;
+      this->Strong = r.Strong;
+      this->backtrace = r.backtrace;
+      return *this;
+  }
+
   operator int() const { return this->Dest; }
 
   bool IsStrong() const { return this->Strong; }
+
+  cmListFileBacktrace const & Backtrace() const { return this->backtrace; }
+
 private:
   int Dest;
   bool Strong;
+  cmListFileBacktrace backtrace;
 };
 struct cmGraphEdgeList : public std::vector<cmGraphEdge>
 {

--- a/Source/cmGraphAdjacencyList.h
+++ b/Source/cmGraphAdjacencyList.h
@@ -26,7 +26,7 @@ public:
     }
   }
 
-  // Graph edges may be copied and assigned as values. (Move semantics not supported on all platforms?)
+  // Graph edges may be copied and assigned as values.
   cmGraphEdge(cmGraphEdge const& r)
      : Dest(r.Dest)
      , Strong(r.Strong)
@@ -46,7 +46,7 @@ public:
 
   bool IsStrong() const { return this->Strong; }
 
-  cmListFileBacktrace const & Backtrace() const { return this->backtrace; }
+  cmListFileBacktrace const& Backtrace() const { return this->backtrace; }
 
 private:
   int Dest;

--- a/Source/cmIfCommand.cxx
+++ b/Source/cmIfCommand.cxx
@@ -104,7 +104,7 @@ bool cmIfFunctionBlocker::IsFunctionBlocked(const cmListFileFunction& lff,
 
             cmListFileContext conditionContext =
               cmListFileContext::FromCommandContext(
-                func, this->GetStartingContext().FilePath);
+                func, this->GetStartingContext().FilePath());
 
             cmConditionEvaluator conditionEvaluator(mf, conditionContext,
                                                     mf.GetBacktrace(func));

--- a/Source/cmIncludeExternalMSProjectCommand.cxx
+++ b/Source/cmIncludeExternalMSProjectCommand.cxx
@@ -82,14 +82,14 @@ bool cmIncludeExternalMSProjectCommand::InitialPass(
     cmTarget* target = this->Makefile->AddNewTarget(cmStateEnums::UTILITY,
                                                     utility_name.c_str());
 
-    target->SetProperty("GENERATOR_FILE_NAME", utility_name.c_str());
-    target->SetProperty("EXTERNAL_MSPROJECT", path.c_str());
-    target->SetProperty("EXCLUDE_FROM_ALL", "FALSE");
+    target->SetProperty("GENERATOR_FILE_NAME", utility_name.c_str(), target->GetBacktrace());
+    target->SetProperty("EXTERNAL_MSPROJECT", path.c_str(), target->GetBacktrace());
+    target->SetProperty("EXCLUDE_FROM_ALL", "FALSE", target->GetBacktrace());
 
     if (!customType.empty())
-      target->SetProperty("VS_PROJECT_TYPE", customType.c_str());
+      target->SetProperty("VS_PROJECT_TYPE", customType.c_str(), target->GetBacktrace());
     if (!platformMapping.empty())
-      target->SetProperty("VS_PLATFORM_MAPPING", platformMapping.c_str());
+      target->SetProperty("VS_PLATFORM_MAPPING", platformMapping.c_str(), target->GetBacktrace());
 
     for (std::string const& d : depends) {
       target->AddUtility(d.c_str());

--- a/Source/cmIncludeGuardCommand.cxx
+++ b/Source/cmIncludeGuardCommand.cxx
@@ -100,7 +100,7 @@ bool cmIncludeGuardCommand::InitialPass(std::vector<std::string> const& args,
         status.SetReturnInvoked();
         return true;
       }
-      cm->SetProperty(includeGuardVar, "TRUE");
+      cm->SetProperty(includeGuardVar, "TRUE", mf->GetBacktrace());
       break;
   }
 

--- a/Source/cmLinkItem.h
+++ b/Source/cmLinkItem.h
@@ -25,14 +25,23 @@ public:
   cmLinkItem()
     : std_string()
     , Target(nullptr)
+    , Backtrace()
   {
   }
   cmLinkItem(const std_string& n, cmGeneratorTarget const* t)
+      : std_string(n)
+      , Target(t)
+      , Backtrace()
+  {
+  }
+  cmLinkItem(const std_string& n, cmGeneratorTarget const* t, cmListFileBacktrace const & bt)
     : std_string(n)
     , Target(t)
+    , Backtrace(bt)
   {
   }
   cmGeneratorTarget const* Target;
+  cmListFileBacktrace Backtrace;
 };
 
 class cmLinkImplItem : public cmLinkItem
@@ -40,18 +49,15 @@ class cmLinkImplItem : public cmLinkItem
 public:
   cmLinkImplItem()
     : cmLinkItem()
-    , Backtrace()
     , FromGenex(false)
   {
   }
   cmLinkImplItem(std::string const& n, cmGeneratorTarget const* t,
                  cmListFileBacktrace const& bt, bool fromGenex)
-    : cmLinkItem(n, t)
-    , Backtrace(bt)
+    : cmLinkItem(n, t, bt)
     , FromGenex(fromGenex)
   {
   }
-  cmListFileBacktrace Backtrace;
   bool FromGenex;
 };
 

--- a/Source/cmLinkedTree.h
+++ b/Source/cmLinkedTree.h
@@ -114,6 +114,11 @@ public:
       return !(*this == other);
     }
 
+    bool operator<(iterator other) const
+    {
+      return StrictWeakOrdered(other);
+    }
+
     bool IsValid() const
     {
       if (!this->Tree) {

--- a/Source/cmListFileCache.cxx
+++ b/Source/cmListFileCache.cxx
@@ -531,6 +531,12 @@ cmListFileBacktrace::ConvertFrameIds(
   return std::move(results);
 }
 
+const cmListFileBacktrace & cmListFileBacktrace::Empty()
+{
+  static cmListFileBacktrace empty;
+  return empty;
+}
+
 std::ostream& operator<<(std::ostream& os, cmListFileContext const& lfc)
 {
   os << lfc.FilePath();

--- a/Source/cmListFileCache.cxx
+++ b/Source/cmListFileCache.cxx
@@ -8,6 +8,7 @@
 #include "cmState.h"
 #include "cmSystemTools.h"
 #include "cmake.h"
+#include "cmStringTable.h"
 
 #include <algorithm>
 #include <assert.h>
@@ -62,9 +63,7 @@ void cmListFileParser::IssueFileOpenError(const std::string& text) const
 
 void cmListFileParser::IssueError(const std::string& text) const
 {
-  cmListFileContext lfc;
-  lfc.FilePath = this->FileName;
-  lfc.Line = cmListFileLexer_GetCurrentLine(this->Lexer);
+  cmListFileContext lfc(this->FileName, cmListFileLexer_GetCurrentLine(this->Lexer));
   cmListFileBacktrace lfbt = this->Backtrace;
   lfbt = lfbt.Push(lfc);
   this->Messenger->IssueMessage(cmake::FATAL_ERROR, text, lfbt);
@@ -238,9 +237,7 @@ bool cmListFileParser::ParseFunction(const char* name, long line)
   }
 
   std::ostringstream error;
-  cmListFileContext lfc;
-  lfc.FilePath = this->FileName;
-  lfc.Line = lastLine;
+  cmListFileContext lfc(this->FileName, lastLine);
   cmListFileBacktrace lfbt = this->Backtrace;
   lfbt = lfbt.Push(lfc);
   error << "Parse error.  Function missing ending \")\".  "
@@ -260,9 +257,7 @@ bool cmListFileParser::AddArgument(cmListFileLexer_Token* token,
   bool isError = (this->Separation == SeparationError ||
                   delim == cmListFileArgument::Bracket);
   std::ostringstream m;
-  cmListFileContext lfc;
-  lfc.FilePath = this->FileName;
-  lfc.Line = token->line;
+  cmListFileContext lfc(this->FileName, token->line);
   cmListFileBacktrace lfbt = this->Backtrace;
   lfbt = lfbt.Push(lfc);
 
@@ -276,6 +271,42 @@ bool cmListFileParser::AddArgument(cmListFileLexer_Token* token,
   }
   this->Messenger->IssueMessage(cmake::AUTHOR_WARNING, m.str(), lfbt);
   return true;
+}
+
+cmListFileContext::cmListFileContext(const std::string & name, const std::string & file, long line)
+  : NameId(cmStringTable::GetStringId(name))
+  , FilePathId(cmStringTable::GetStringId(file))
+  , Line(line)
+{
+}
+
+cmListFileContext::cmListFileContext(const std::string & file, long line)
+  : NameId(0)
+  , FilePathId(cmStringTable::GetStringId(file))
+  , Line(line)
+{
+}
+
+cmListFileContext cmListFileContext::FromCommandContext(cmCommandContext const& lfcc,
+  std::string const& fileName)
+{
+  cmListFileContext result(lfcc.Name, fileName, lfcc.Line);
+  return result;
+}
+
+void cmListFileContext::UpdateFilePath(const std::string & newFile)
+{
+  FilePathId = cmStringTable::GetStringId(newFile);
+}
+
+const std::string & cmListFileContext::Name() const
+{
+  return cmStringTable::GetString(NameId);
+}
+
+const std::string & cmListFileContext::FilePath() const
+{
+  return cmStringTable::GetString(FilePathId);
 }
 
 std::map<size_t, cmListFileContext> s_idToFrameMap;
@@ -385,8 +416,7 @@ cmListFileBacktrace cmListFileBacktrace::Push(std::string const& file) const
   // any specific line or command invocation within it.  This context
   // is useful to print when it is at the top but otherwise can be
   // skipped during call stack printing.
-  cmListFileContext lfc;
-  lfc.FilePath = file;
+  cmListFileContext lfc(file, 0);
   return cmListFileBacktrace(this->Bottom, this->Cur, lfc);
 }
 
@@ -418,9 +448,10 @@ void cmListFileBacktrace::PrintTitle(std::ostream& out) const
   }
   cmOutputConverter converter(this->Bottom);
   cmListFileContext lfc = *this->Cur;
-  if (!this->Bottom.GetState()->GetIsInTryCompile()) {
-    lfc.FilePath = converter.ConvertToRelativePath(
-      this->Bottom.GetState()->GetSourceDirectory(), lfc.FilePath);
+  cmState* state = this->Bottom.GetState();
+  if (state && !state->GetIsInTryCompile()) {
+    lfc.UpdateFilePath(converter.ConvertToRelativePath(
+      state->GetSourceDirectory(), lfc.FilePath()));
   }
   out << (lfc.Line ? " at " : " in ") << lfc;
 }
@@ -433,8 +464,9 @@ void cmListFileBacktrace::PrintCallStack(std::ostream& out) const
 
   bool first = true;
   cmOutputConverter converter(this->Bottom);
+  cmState* state = this->Bottom.GetState();
   for (Entry* i = this->Cur->Up; i; i = i->Up) {
-    if (i->Name.empty()) {
+    if (!i->HasName()) {
       // Skip this whole-file scope.  When we get here we already will
       // have printed a more-specific context within the file.
       continue;
@@ -444,9 +476,9 @@ void cmListFileBacktrace::PrintCallStack(std::ostream& out) const
       out << "Call Stack (most recent call first):\n";
     }
     cmListFileContext lfc = *i;
-    if (!this->Bottom.GetState()->GetIsInTryCompile()) {
-      lfc.FilePath = converter.ConvertToRelativePath(
-        this->Bottom.GetState()->GetSourceDirectory(), lfc.FilePath);
+    if (state && !state->GetIsInTryCompile()) {
+      lfc.UpdateFilePath(converter.ConvertToRelativePath(
+        state->GetSourceDirectory(), lfc.FilePath()));
     }
     out << "  " << lfc << "\n";
   }
@@ -465,25 +497,29 @@ size_t cmListFileBacktrace::Depth() const
   return depth;
 }
 
-std::vector<size_t> const & cmListFileBacktrace::GetFrameIds() const
+std::vector<size_t> const& cmListFileBacktrace::GetFrameIds() const
 {
-  bool inTryCompile = this->Bottom.GetState()->GetIsInTryCompile();
-  auto & frameIds = inTryCompile ? this->CompilingFrameIds : this->NonCompilingFrameIds;
+  cmState* state = this->Bottom.GetState();
+  bool inTryCompile = state && state->GetIsInTryCompile();
+  auto& frameIds =
+    inTryCompile ? this->CompilingFrameIds : this->NonCompilingFrameIds;
   if (this->Cur != nullptr && frameIds.empty()) {
-      cmOutputConverter converter(this->Bottom);
-      for (Entry* i = this->Cur; i; i = i->Up) {
-        cmListFileContext lfc = *i;
-        if (inTryCompile) {
-          lfc.FilePath = converter.ConvertToRelativePath(
-            this->Bottom.GetState()->GetSourceDirectory(), lfc.FilePath);
-        }
-        frameIds.emplace_back(ComputeFrameId(lfc));
+    cmOutputConverter converter(this->Bottom);
+    for (Entry* i = this->Cur; i; i = i->Up) {
+      cmListFileContext lfc = *i;
+      if (!inTryCompile && state) {
+        lfc.UpdateFilePath(converter.ConvertToRelativePath(
+          state->GetSourceDirectory(), lfc.FilePath()));
       }
+      frameIds.emplace_back(ComputeFrameId(lfc));
     }
+  }
   return frameIds;
 }
 
-std::vector<std::pair<size_t, cmListFileContext>> cmListFileBacktrace::ConvertFrameIds(std::unordered_set<size_t> const & frameIds)
+std::vector<std::pair<size_t, cmListFileContext>>
+cmListFileBacktrace::ConvertFrameIds(
+  std::unordered_set<size_t> const& frameIds)
 {
   std::vector<std::pair<size_t, cmListFileContext>> results;
   for (auto id : frameIds) {
@@ -495,14 +531,13 @@ std::vector<std::pair<size_t, cmListFileContext>> cmListFileBacktrace::ConvertFr
   return std::move(results);
 }
 
-
 std::ostream& operator<<(std::ostream& os, cmListFileContext const& lfc)
 {
-  os << lfc.FilePath;
+  os << lfc.FilePath();
   if (lfc.Line) {
     os << ":" << lfc.Line;
-    if (!lfc.Name.empty()) {
-      os << " (" << lfc.Name << ")";
+    if (lfc.HasName()) {
+      os << " (" << lfc.Name() << ")";
     }
   }
   return os;
@@ -513,12 +548,14 @@ bool operator<(const cmListFileContext& lhs, const cmListFileContext& rhs)
   if (lhs.Line != rhs.Line) {
     return lhs.Line < rhs.Line;
   }
-  return lhs.FilePath < rhs.FilePath;
+
+  // Do we really need sorting here or is this just for lookup in a map?
+  return lhs.FilePathId < rhs.FilePathId;
 }
 
 bool operator==(const cmListFileContext& lhs, const cmListFileContext& rhs)
 {
-  return lhs.Line == rhs.Line && lhs.FilePath == rhs.FilePath;
+  return lhs.Line == rhs.Line && lhs.FilePathId == rhs.FilePathId;
 }
 
 bool operator!=(const cmListFileContext& lhs, const cmListFileContext& rhs)

--- a/Source/cmListFileCache.cxx
+++ b/Source/cmListFileCache.cxx
@@ -499,22 +499,13 @@ size_t cmListFileBacktrace::Depth() const
 
 std::vector<size_t> const& cmListFileBacktrace::GetFrameIds() const
 {
-  cmState* state = this->Bottom.GetState();
-  bool inTryCompile = state && state->GetIsInTryCompile();
-  auto& frameIds =
-    inTryCompile ? this->CompilingFrameIds : this->NonCompilingFrameIds;
-  if (this->Cur != nullptr && frameIds.empty()) {
-    cmOutputConverter converter(this->Bottom);
+  if (this->Cur != nullptr && FrameIds.empty()) {
     for (Entry* i = this->Cur; i; i = i->Up) {
       cmListFileContext lfc = *i;
-      if (!inTryCompile && state) {
-        lfc.UpdateFilePath(converter.ConvertToRelativePath(
-          state->GetSourceDirectory(), lfc.FilePath()));
-      }
-      frameIds.emplace_back(ComputeFrameId(lfc));
+      FrameIds.emplace_back(ComputeFrameId(lfc));
     }
   }
-  return frameIds;
+  return FrameIds;
 }
 
 std::vector<std::pair<size_t, cmListFileContext>>

--- a/Source/cmListFileCache.h
+++ b/Source/cmListFileCache.h
@@ -66,25 +66,32 @@ struct cmListFileArgument
 class cmListFileContext
 {
 public:
-  std::string Name;
-  std::string FilePath;
+  const std::string & Name() const;
+  const std::string & FilePath() const;
   long Line;
   cmListFileContext()
-    : Name()
-    , FilePath()
+    : NameId(0)
+    , FilePathId(0)
     , Line(0)
   {
   }
+  cmListFileContext(const std::string & name, const std::string & file, long line);
+  cmListFileContext(const std::string & file, long line);
 
   static cmListFileContext FromCommandContext(cmCommandContext const& lfcc,
-                                              std::string const& fileName)
-  {
-    cmListFileContext lfc;
-    lfc.FilePath = fileName;
-    lfc.Line = lfcc.Line;
-    lfc.Name = lfcc.Name;
-    return lfc;
-  }
+    std::string const& fileName);
+
+  void UpdateFilePath(const std::string & newFile);
+
+  bool HasName() const { return NameId != 0; }
+  bool HasFilePath() const { return FilePathId != 0; }
+
+  friend bool operator<(const cmListFileContext& lhs, const cmListFileContext& rhs);
+  friend bool operator==(const cmListFileContext& lhs, const cmListFileContext& rhs);
+
+private:
+  size_t NameId;
+  size_t FilePathId;
 };
 
 std::ostream& operator<<(std::ostream&, cmListFileContext const&);

--- a/Source/cmListFileCache.h
+++ b/Source/cmListFileCache.h
@@ -168,8 +168,7 @@ private:
                       cmListFileContext const& lfc);
   cmListFileBacktrace(cmStateSnapshot const& bottom, Entry* cur);
   
-  std::vector<size_t> mutable NonCompilingFrameIds;
-  std::vector<size_t> mutable CompilingFrameIds;
+  std::vector<size_t> mutable FrameIds;
 };
 
 struct cmListFile

--- a/Source/cmListFileCache.h
+++ b/Source/cmListFileCache.h
@@ -156,6 +156,9 @@ public:
   // Convert a list of frame ids into their actual representation
   static std::vector<std::pair<size_t, cmListFileContext>> ConvertFrameIds(std::unordered_set<size_t> const & frameIds);
 
+  // Returns an empty backfile trace for when a callstack isn't practical to find.
+  static const cmListFileBacktrace & Empty();
+
 private:
   struct Entry;
 

--- a/Source/cmListFileCache.h
+++ b/Source/cmListFileCache.h
@@ -9,6 +9,7 @@
 #include <stddef.h>
 #include <string>
 #include <vector>
+#include <deque>
 
 #include "cmStateSnapshot.h"
 
@@ -115,7 +116,7 @@ public:
   cmListFileBacktrace& operator=(cmListFileBacktrace const& r);
   ~cmListFileBacktrace();
 
-  cmStateSnapshot GetBottom() const { return this->Bottom; }
+  cmStateSnapshot const& GetBottom() const;
 
   // Get a backtrace with the given file scope added to the top.
   // May not be called until after construction with a valid snapshot.
@@ -143,13 +144,8 @@ public:
   size_t Depth() const;
 
 private:
-  struct Entry;
-
-  cmStateSnapshot Bottom;
-  Entry* Cur;
-  cmListFileBacktrace(cmStateSnapshot const& bottom, Entry* up,
-                      cmListFileContext const& lfc);
-  cmListFileBacktrace(cmStateSnapshot const& bottom, Entry* cur);
+  std::deque<size_t> Entries;
+  size_t SnapshotId;
 };
 
 struct cmListFile

--- a/Source/cmLocalVisualStudio7Generator.cxx
+++ b/Source/cmLocalVisualStudio7Generator.cxx
@@ -196,7 +196,7 @@ void cmLocalVisualStudio7Generator::CreateSingleVCProj(
   }
 
   // add to the list of projects
-  target->Target->SetProperty("GENERATOR_FILE_NAME", lname.c_str());
+  target->Target->SetProperty("GENERATOR_FILE_NAME", lname.c_str(), target->Target->GetBacktrace());
   // create the dsp.cmake file
   std::string fname;
   fname = this->GetCurrentBinaryDirectory();

--- a/Source/cmMacroCommand.cxx
+++ b/Source/cmMacroCommand.cxx
@@ -170,7 +170,7 @@ bool cmMacroFunctionBlocker::IsFunctionBlocked(const cmListFileFunction& lff,
       cmMacroHelperCommand* f = new cmMacroHelperCommand();
       f->Args = this->Args;
       f->Functions = this->Functions;
-      f->FilePath = this->GetStartingContext().FilePath;
+      f->FilePath = this->GetStartingContext().FilePath();
       mf.RecordPolicies(f->Policies);
       mf.GetState()->AddScriptedCommand(this->Args[0], f);
       // remove the function blocker now that the macro is defined
@@ -193,7 +193,7 @@ bool cmMacroFunctionBlocker::ShouldRemove(const cmListFileFunction& lff,
   if (!cmSystemTools::Strucmp(lff.Name.c_str(), "endmacro")) {
     std::vector<std::string> expandedArguments;
     mf.ExpandArguments(lff.Arguments, expandedArguments,
-                       this->GetStartingContext().FilePath.c_str());
+                       this->GetStartingContext().FilePath().c_str());
     // if the endmacro has arguments make sure they
     // match the arguments of the macro
     if ((expandedArguments.empty() ||

--- a/Source/cmMakefile.cxx
+++ b/Source/cmMakefile.cxx
@@ -303,6 +303,9 @@ bool cmMakefile::ExecuteCommand(const cmListFileFunction& lff,
     // Clone the prototype.
     std::unique_ptr<cmCommand> pcmd(proto->Clone());
     pcmd->SetMakefile(this);
+    if (this->GetCMakeInstance()->IsServerMode()) {
+      pcmd->SetBacktrace(this->Backtrace);
+    }
 
     // Decide whether to invoke the command.
     if (!cmSystemTools::GetFatalErrorOccured()) {

--- a/Source/cmMakefile.cxx
+++ b/Source/cmMakefile.cxx
@@ -1832,7 +1832,7 @@ void cmMakefile::AddGlobalLinkInformation(cmTarget& target)
         libraryName = *j;
       }
       // This is equivalent to the target_link_libraries plain signature.
-      target.AddLinkLibrary(*this, libraryName, libType);
+      target.AddLinkLibrary(*this, libraryName, libType, linkLibsBacktrace);
       target.AppendProperty(
         "INTERFACE_LINK_LIBRARIES",
         target.GetDebugGeneratorExpressions(libraryName, libType).c_str(),

--- a/Source/cmMakefile.cxx
+++ b/Source/cmMakefile.cxx
@@ -198,20 +198,14 @@ cmListFileBacktrace cmMakefile::GetBacktrace() const
 
 cmListFileBacktrace cmMakefile::GetBacktrace(cmCommandContext const& cc) const
 {
-  cmListFileContext lfc;
-  lfc.Name = cc.Name;
-  lfc.Line = cc.Line;
-  lfc.FilePath = this->StateSnapshot.GetExecutionListFile();
+  cmListFileContext lfc(cc.Name, this->StateSnapshot.GetExecutionListFile(), cc.Line);
   return this->Backtrace.Push(lfc);
 }
 
 cmListFileContext cmMakefile::GetExecutionContext() const
 {
   cmListFileContext const& cur = this->Backtrace.Top();
-  cmListFileContext lfc;
-  lfc.Name = cur.Name;
-  lfc.Line = cur.Line;
-  lfc.FilePath = this->StateSnapshot.GetExecutionListFile();
+  cmListFileContext lfc(cur.Name(), this->StateSnapshot.GetExecutionListFile(), cur.Line);
   return lfc;
 }
 
@@ -1752,7 +1746,7 @@ void cmMakefile::LogUnused(const char* reason, const std::string& name) const
   if (this->WarnUnused) {
     std::string path;
     if (!this->ExecutionStatusStack.empty()) {
-      path = this->GetExecutionContext().FilePath;
+      path = this->GetExecutionContext().FilePath();
     } else {
       path = this->GetCurrentSourceDirectory();
       path += "/CMakeLists.txt";
@@ -3072,7 +3066,7 @@ std::unique_ptr<cmFunctionBlocker> cmMakefile::RemoveFunctionBlocker(
       if (!(*pos)->ShouldRemove(lff, *this)) {
         cmListFileContext const& lfc = fb->GetStartingContext();
         cmListFileContext closingContext =
-          cmListFileContext::FromCommandContext(lff, lfc.FilePath);
+          cmListFileContext::FromCommandContext(lff, lfc.FilePath());
         std::ostringstream e;
         /* clang-format off */
         e << "A logical block opening on the line\n"

--- a/Source/cmMakefile.h
+++ b/Source/cmMakefile.h
@@ -663,6 +663,7 @@ public:
   const char* GetProperty(const std::string& prop, bool chain) const;
   bool GetPropertyAsBool(const std::string& prop) const;
   std::vector<std::string> GetPropertyKeys() const;
+  const cmListFileBacktrace & GetPropertyBacktrace(const std::string & prop) const;
 
   ///! Initialize a makefile from its parent
   void InitializeFromParent(cmMakefile* parent);

--- a/Source/cmProperty.cxx
+++ b/Source/cmProperty.cxx
@@ -2,19 +2,21 @@
    file Copyright.txt or https://cmake.org/licensing for details.  */
 #include "cmProperty.h"
 
-void cmProperty::Set(const char* value)
+void cmProperty::Set(const char* value, const cmListFileBacktrace & backtrace)
 {
   this->Value = value;
   this->ValueHasBeenSet = true;
+  this->Backtrace = backtrace;
 }
 
-void cmProperty::Append(const char* value, bool asString)
+void cmProperty::Append(const char* value, const cmListFileBacktrace & backtrace, bool asString)
 {
   if (!this->Value.empty() && *value && !asString) {
     this->Value += ";";
   }
   this->Value += value;
   this->ValueHasBeenSet = true;
+  this->Backtrace = backtrace;
 }
 
 const char* cmProperty::GetValue() const

--- a/Source/cmProperty.h
+++ b/Source/cmProperty.h
@@ -4,6 +4,7 @@
 #define cmProperty_h
 
 #include "cmConfigure.h" // IWYU pragma: keep
+#include "cmListFileCache.h"
 
 #include <string>
 
@@ -24,13 +25,16 @@ public:
   };
 
   // set this property
-  void Set(const char* value);
+  void Set(const char* value, const cmListFileBacktrace & backtrace);
 
   // append to this property
-  void Append(const char* value, bool asString = false);
+  void Append(const char* value, const cmListFileBacktrace & backtrace, bool asString = false);
 
   // get the value
   const char* GetValue() const;
+
+  // get the backtrace for last set or append
+  const cmListFileBacktrace & GetBacktrace() const { return Backtrace; }
 
   // construct with the value not set
   cmProperty() { this->ValueHasBeenSet = false; }
@@ -38,6 +42,7 @@ public:
 protected:
   std::string Value;
   bool ValueHasBeenSet;
+  cmListFileBacktrace Backtrace;
 };
 
 #endif

--- a/Source/cmPropertyMap.cxx
+++ b/Source/cmPropertyMap.cxx
@@ -28,7 +28,7 @@ std::vector<std::string> cmPropertyMap::GetPropertyList() const
   return keyList;
 }
 
-void cmPropertyMap::SetProperty(const std::string& name, const char* value)
+void cmPropertyMap::SetProperty(const std::string& name, const char* value, const cmListFileBacktrace & backtrace)
 {
   if (!value) {
     this->erase(name);
@@ -36,10 +36,10 @@ void cmPropertyMap::SetProperty(const std::string& name, const char* value)
   }
 
   cmProperty* prop = this->GetOrCreateProperty(name);
-  prop->Set(value);
+  prop->Set(value, backtrace);
 }
 
-void cmPropertyMap::AppendProperty(const std::string& name, const char* value,
+void cmPropertyMap::AppendProperty(const std::string& name, const char* value, const cmListFileBacktrace & backtrace,
                                    bool asString)
 {
   // Skip if nothing to append.
@@ -48,7 +48,7 @@ void cmPropertyMap::AppendProperty(const std::string& name, const char* value,
   }
 
   cmProperty* prop = this->GetOrCreateProperty(name);
-  prop->Append(value, asString);
+  prop->Append(value, backtrace, asString);
 }
 
 const char* cmPropertyMap::GetPropertyValue(const std::string& name) const
@@ -60,4 +60,24 @@ const char* cmPropertyMap::GetPropertyValue(const std::string& name) const
     return nullptr;
   }
   return it->second.GetValue();
+}
+
+const cmListFileBacktrace & cmPropertyMap::GetPropertyBacktrace(const std::string & name) const
+{
+  assert(!name.empty());
+
+  cmPropertyMap::const_iterator it = this->find(name);
+  if (it == this->end()) {
+    return cmListFileBacktrace::Empty();
+  }
+  return it->second.GetBacktrace();
+}
+
+
+bool cmPropertyMap::HasProperty(const std::string & name) const
+{
+  assert(!name.empty());
+
+  auto it = this->find(name);
+  return it != this->end();
 }

--- a/Source/cmPropertyMap.h
+++ b/Source/cmPropertyMap.h
@@ -18,12 +18,16 @@ public:
 
   std::vector<std::string> GetPropertyList() const;
 
-  void SetProperty(const std::string& name, const char* value);
+  void SetProperty(const std::string& name, const char* value, const cmListFileBacktrace & backtrace);
 
-  void AppendProperty(const std::string& name, const char* value,
+  void AppendProperty(const std::string& name, const char* value, const cmListFileBacktrace & backtrace,
                       bool asString = false);
 
   const char* GetPropertyValue(const std::string& name) const;
+
+  const cmListFileBacktrace & GetPropertyBacktrace(const std::string & name) const;
+
+  bool HasProperty(const std::string & name) const;
 };
 
 #endif

--- a/Source/cmQtAutoGeneratorInitializer.cxx
+++ b/Source/cmQtAutoGeneratorInitializer.cxx
@@ -693,7 +693,7 @@ void cmQtAutoGeneratorInitializer::InitCustomTargets()
 
           // Set FOLDER property in autogen target
           if (!this->AutogenFolder.empty()) {
-            autoRccTarget->SetProperty("FOLDER", this->AutogenFolder.c_str());
+            autoRccTarget->SetProperty("FOLDER", this->AutogenFolder.c_str(), autoRccTarget->GetBacktrace());
           }
         }
         // Add autogen target to the origin target dependencies
@@ -871,7 +871,7 @@ void cmQtAutoGeneratorInitializer::InitCustomTargets()
 
       // Set FOLDER property in autogen target
       if (!this->AutogenFolder.empty()) {
-        autogenTarget->SetProperty("FOLDER", this->AutogenFolder.c_str());
+        autogenTarget->SetProperty("FOLDER", this->AutogenFolder.c_str(), autogenTarget->GetBacktrace());
       }
 
       // Add autogen target to the origin target dependencies

--- a/Source/cmServerDictionary.h
+++ b/Source/cmServerDictionary.h
@@ -4,7 +4,7 @@
 
 #include <string>
 
-// Vocabulary:
+   // Vocabulary:
 
 static const std::string kDIRTY_SIGNAL = "dirty";
 static const std::string kFILE_CHANGE_SIGNAL = "fileChange";
@@ -74,8 +74,7 @@ static const std::string kPROTOCOL_VERSION_KEY = "protocolVersion";
 static const std::string kREPLY_TO_KEY = "inReplyTo";
 static const std::string kSOURCE_DIRECTORY_KEY = "sourceDirectory";
 static const std::string kSOURCES_KEY = "sources";
-static const std::string kSUPPORTED_PROTOCOL_VERSIONS =
-  "supportedProtocolVersions";
+static const std::string kSUPPORTED_PROTOCOL_VERSIONS = "supportedProtocolVersions";
 static const std::string kSYSROOT_KEY = "sysroot";
 static const std::string kTARGETS_KEY = "targets";
 static const std::string kTITLE_KEY = "title";
@@ -101,6 +100,7 @@ static const std::string kTARGET_CROSS_REFERENCES_KEY = "crossReferences";
 static const std::string kLINE_NUMBER_KEY = "line";
 static const std::string kBACKTRACE_KEY = "backtrace";
 static const std::string kRELATED_STATEMENTS_KEY = "relatedStatements";
+static const std::string KTARGET_DEPENDENCIES_KEY = "dependencies";
 
 static const std::string kSTART_MAGIC = "[== \"CMake Server\" ==[";
 static const std::string kEND_MAGIC = "]== \"CMake Server\" ==]";

--- a/Source/cmServerProtocol.cxx
+++ b/Source/cmServerProtocol.cxx
@@ -262,7 +262,7 @@ std::pair<int, int> cmServerProtocol1::ProtocolVersion() const
 
 std::pair<int, int> cmServerProtocol2::ProtocolVersion() const
 {
-  return std::make_pair(2, 0);
+  return std::make_pair(2, 1);
 }
 
 static void setErrorMessage(std::string* errorMessage, const std::string& text)

--- a/Source/cmServerProtocol.cxx
+++ b/Source/cmServerProtocol.cxx
@@ -1466,11 +1466,14 @@ cmServerResponse cmServerProtocol2::ProcessCTests(
     return request.ReportError("This instance was not yet computed.");
   }
 
+  auto includeTraces = request.Data[kINCLUDE_TRACES_KEY].asBool();
   Json::Value result = Json::objectValue;
   std::unordered_set<size_t> seenTraceIds;
   result[kCONFIGURATIONS_KEY] =
-    DumpCTestConfigurationsList(this->CMakeInstance(), &seenTraceIds);
-  result[KREFERENCED_TRACES_KEY] = DumpReferencedTraces(seenTraceIds);
+    DumpCTestConfigurationsList(this->CMakeInstance(), includeTraces ? &seenTraceIds : nullptr);
+  if (includeTraces) {
+    result[KREFERENCED_TRACES_KEY] = DumpReferencedTraces(seenTraceIds);
+  }
   return request.Reply(result);
 }
 

--- a/Source/cmServerProtocol.cxx
+++ b/Source/cmServerProtocol.cxx
@@ -257,7 +257,7 @@ bool cmServerProtocol::DoActivate(const cmServerRequest& /*request*/,
 
 std::pair<int, int> cmServerProtocol1::ProtocolVersion() const
 {
-  return std::make_pair(1, 2);
+  return std::make_pair(1, 3);
 }
 
 static void setErrorMessage(std::string* errorMessage, const std::string& text)
@@ -880,6 +880,7 @@ static Json::Value DumpCTestConfigurationsList(const cmake* cm)
 static Json::Value DumpTarget(cmGeneratorTarget* target,
                               const std::string& config)
 {
+  cmGlobalGenerator* g = target->GetGlobalGenerator();
   cmLocalGenerator* lg = target->GetLocalGenerator();
   const cmState* state = lg->GetState();
 
@@ -956,6 +957,13 @@ static Json::Value DumpTarget(cmGeneratorTarget* target,
 
   crossRefs[kRELATED_STATEMENTS_KEY] = std::move(statements);
   result[kTARGET_CROSS_REFERENCES_KEY] = std::move(crossRefs);
+
+  cmGlobalGenerator::TargetDependSet const& tgtdeps = g->GetTargetDirectDepends(target);
+  Json::Value dependencies = Json::arrayValue;
+  for (auto const & depend : tgtdeps) {
+      dependencies.append(depend->GetFullName(config));
+  }
+  result[KTARGET_DEPENDENCIES_KEY] = dependencies;
 
   if (target->HaveWellDefinedOutputFiles()) {
     Json::Value artifacts = Json::arrayValue;

--- a/Source/cmServerProtocol.cxx
+++ b/Source/cmServerProtocol.cxx
@@ -961,7 +961,10 @@ static Json::Value DumpTarget(cmGeneratorTarget* target,
   cmGlobalGenerator::TargetDependSet const& tgtdeps = g->GetTargetDirectDepends(target);
   Json::Value dependencies = Json::arrayValue;
   for (auto const & depend : tgtdeps) {
-      dependencies.append(depend->GetFullName(config));
+      Json::Value obj = Json::objectValue;
+      obj[kNAME_KEY] = depend->GetFullName(config);
+      obj[kBACKTRACE_KEY] = DumpBacktrace(depend.Backtrace());
+      dependencies.append(obj);
   }
   result[KTARGET_DEPENDENCIES_KEY] = dependencies;
 

--- a/Source/cmSetPropertyCommand.cxx
+++ b/Source/cmSetPropertyCommand.cxx
@@ -144,9 +144,9 @@ bool cmSetPropertyCommand::HandleGlobalMode()
     value = nullptr;
   }
   if (this->AppendMode) {
-    cm->AppendProperty(name, value ? value : "", this->AppendAsString);
+    cm->AppendProperty(name, value ? value : "", this->Makefile->GetBacktrace(), this->AppendAsString);
   } else {
-    cm->SetProperty(name, value);
+    cm->SetProperty(name, value, this->Makefile->GetBacktrace());
   }
 
   return true;
@@ -234,9 +234,9 @@ bool cmSetPropertyCommand::HandleTarget(cmTarget* target)
     value = nullptr;
   }
   if (this->AppendMode) {
-    target->AppendProperty(name, value, this->AppendAsString);
+    target->AppendProperty(name, value, this->GetBacktrace(), this->AppendAsString);
   } else {
-    target->SetProperty(name, value);
+    target->SetProperty(name, value, this->GetBacktrace());
   }
 
   // Check the resulting value.

--- a/Source/cmSetTargetPropertiesCommand.cxx
+++ b/Source/cmSetTargetPropertiesCommand.cxx
@@ -68,7 +68,7 @@ bool cmSetTargetPropertiesCommand::SetOneTarget(
     // now loop through all the props and set them
     unsigned int k;
     for (k = 0; k < propertyPairs.size(); k = k + 2) {
-      target->SetProperty(propertyPairs[k], propertyPairs[k + 1].c_str());
+      target->SetProperty(propertyPairs[k], propertyPairs[k + 1].c_str(), target->GetBacktrace());
       target->CheckProperty(propertyPairs[k], mf);
     }
   }

--- a/Source/cmSourceFile.cxx
+++ b/Source/cmSourceFile.cxx
@@ -238,13 +238,15 @@ bool cmSourceFile::Matches(cmSourceFileLocation const& loc)
 
 void cmSourceFile::SetProperty(const std::string& prop, const char* value)
 {
-  this->Properties.SetProperty(prop, value);
+  cmMakefile const* mf = this->Location.GetMakefile();
+  this->Properties.SetProperty(prop, value, mf->GetBacktrace());
 }
 
 void cmSourceFile::AppendProperty(const std::string& prop, const char* value,
                                   bool asString)
 {
-  this->Properties.AppendProperty(prop, value, asString);
+  cmMakefile const* mf = this->Location.GetMakefile();
+  this->Properties.AppendProperty(prop, value, mf->GetBacktrace(), asString);
 }
 
 const char* cmSourceFile::GetPropertyForUser(const std::string& prop)

--- a/Source/cmState.cxx
+++ b/Source/cmState.cxx
@@ -411,6 +411,10 @@ void cmState::AddScriptedCommand(std::string const& name, cmCommand* command)
       delete pos->second;
       this->ScriptedCommands.erase(pos);
     }
+    cmCommand * clone = oldCmd->Clone();
+    clone->SetMakefile(oldCmd->GetMakefile());
+    clone->SetBacktrace(oldCmd->GetBacktrace());
+
     this->ScriptedCommands.insert(std::make_pair(newName, oldCmd->Clone()));
   }
 
@@ -462,35 +466,35 @@ void cmState::RemoveUserDefinedCommands()
   this->ScriptedCommands.clear();
 }
 
-void cmState::SetGlobalProperty(const std::string& prop, const char* value)
+void cmState::SetGlobalProperty(const std::string& prop, const char* value, const cmListFileBacktrace & backtrace)
 {
-  this->GlobalProperties.SetProperty(prop, value);
+  this->GlobalProperties.SetProperty(prop, value, backtrace);
 }
 
-void cmState::AppendGlobalProperty(const std::string& prop, const char* value,
+void cmState::AppendGlobalProperty(const std::string& prop, const char* value, const cmListFileBacktrace & backtrace,
                                    bool asString)
 {
-  this->GlobalProperties.AppendProperty(prop, value, asString);
+  this->GlobalProperties.AppendProperty(prop, value, backtrace, asString);
 }
 
 const char* cmState::GetGlobalProperty(const std::string& prop)
 {
   if (prop == "CACHE_VARIABLES") {
     std::vector<std::string> cacheKeys = this->GetCacheEntryKeys();
-    this->SetGlobalProperty("CACHE_VARIABLES", cmJoin(cacheKeys, ";").c_str());
+    this->SetGlobalProperty("CACHE_VARIABLES", cmJoin(cacheKeys, ";").c_str(), cmListFileBacktrace::Empty());
   } else if (prop == "COMMANDS") {
     std::vector<std::string> commands = this->GetCommandNames();
-    this->SetGlobalProperty("COMMANDS", cmJoin(commands, ";").c_str());
+    this->SetGlobalProperty("COMMANDS", cmJoin(commands, ";").c_str(), cmListFileBacktrace::Empty());
   } else if (prop == "IN_TRY_COMPILE") {
     this->SetGlobalProperty("IN_TRY_COMPILE",
-                            this->IsInTryCompile ? "1" : "0");
+                            this->IsInTryCompile ? "1" : "0", cmListFileBacktrace::Empty());
   } else if (prop == "GENERATOR_IS_MULTI_CONFIG") {
     this->SetGlobalProperty("GENERATOR_IS_MULTI_CONFIG",
-                            this->IsGeneratorMultiConfig ? "1" : "0");
+                            this->IsGeneratorMultiConfig ? "1" : "0", cmListFileBacktrace::Empty());
   } else if (prop == "ENABLED_LANGUAGES") {
     std::string langs;
     langs = cmJoin(this->EnabledLanguages, ";");
-    this->SetGlobalProperty("ENABLED_LANGUAGES", langs.c_str());
+    this->SetGlobalProperty("ENABLED_LANGUAGES", langs.c_str(), cmListFileBacktrace::Empty());
   }
 #define STRING_LIST_ELEMENT(F) ";" #F
   if (prop == "CMAKE_C_KNOWN_FEATURES") {

--- a/Source/cmState.h
+++ b/Source/cmState.h
@@ -131,8 +131,8 @@ public:
   void RemoveUserDefinedCommands();
   std::vector<std::string> GetCommandNames() const;
 
-  void SetGlobalProperty(const std::string& prop, const char* value);
-  void AppendGlobalProperty(const std::string& prop, const char* value,
+  void SetGlobalProperty(const std::string& prop, const char* value, const cmListFileBacktrace & backtrace);
+  void AppendGlobalProperty(const std::string& prop, const char* value, const cmListFileBacktrace & backtrace,
                             bool asString = false);
   const char* GetGlobalProperty(const std::string& prop);
   bool GetGlobalPropertyAsBool(const std::string& prop);

--- a/Source/cmStateDirectory.h
+++ b/Source/cmStateDirectory.h
@@ -66,6 +66,7 @@ public:
   const char* GetProperty(const std::string& prop, bool chain) const;
   bool GetPropertyAsBool(const std::string& prop) const;
   std::vector<std::string> GetPropertyKeys() const;
+  const cmListFileBacktrace & GetPropertyBacktrace(const std::string & prop) const;
 
   void AddNormalTargetName(std::string const& name);
 

--- a/Source/cmStateSnapshot.cxx
+++ b/Source/cmStateSnapshot.cxx
@@ -435,3 +435,8 @@ bool operator!=(const cmStateSnapshot& lhs, const cmStateSnapshot& rhs)
 {
   return lhs.Position != rhs.Position;
 }
+
+bool operator<(const cmStateSnapshot& lhs, const cmStateSnapshot& rhs)
+{
+  return lhs.Position < rhs.Position;
+}

--- a/Source/cmStateSnapshot.cxx
+++ b/Source/cmStateSnapshot.cxx
@@ -344,7 +344,7 @@ void cmStateSnapshot::SetDefaultDefinitions()
 
   // Setup the default include file regular expression (match everything).
   this->Position->BuildSystemDirectory->Properties.SetProperty(
-    "INCLUDE_REGULAR_EXPRESSION", "^.*$");
+    "INCLUDE_REGULAR_EXPRESSION", "^.*$", cmListFileBacktrace::Empty());
 }
 
 void cmStateSnapshot::SetDirectoryDefinitions()

--- a/Source/cmStateSnapshot.h
+++ b/Source/cmStateSnapshot.h
@@ -72,6 +72,8 @@ private:
                          const cmStateSnapshot& rhs);
   friend bool operator!=(const cmStateSnapshot& lhs,
                          const cmStateSnapshot& rhs);
+  friend bool operator<(const cmStateSnapshot& lhs,
+                        const cmStateSnapshot& rhs);
   friend class cmState;
   friend class cmStateDirectory;
   friend struct StrictWeakOrder;
@@ -84,5 +86,7 @@ private:
 
 bool operator==(const cmStateSnapshot& lhs, const cmStateSnapshot& rhs);
 bool operator!=(const cmStateSnapshot& lhs, const cmStateSnapshot& rhs);
+bool operator<(const cmStateSnapshot& lhs, const cmStateSnapshot& rhs);
+
 
 #endif

--- a/Source/cmStringTable.cxx
+++ b/Source/cmStringTable.cxx
@@ -1,0 +1,58 @@
+/* Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
+file Copyright.txt or https://cmake.org/licensing for details.  */
+#include "cmStringTable.h"
+
+#include <list>
+#include <unordered_map>
+#include <allocators>
+
+struct string_hasher
+{
+  size_t operator()(std::string * k) const
+  {
+    std::hash<std::string> h;
+    return h(*k);
+  }
+};
+
+struct string_comparer
+{
+  bool operator()(const std::string * l, const std::string * r) const
+  {
+    return (*l) == (*r);
+  }
+};
+
+std::list<std::string> _string_storage;
+std::unordered_map<std::string *, size_t, string_hasher, string_comparer> _string_to_id_map;
+std::unordered_map<size_t, std::string *> _id_to_string_map;
+
+size_t cmStringTable::GetStringId(const std::string & str)
+{
+  auto it = _string_to_id_map.find(const_cast<std::string *>(&str));
+  if (it == _string_to_id_map.end()) {
+    _string_storage.emplace_back(str);
+    // As long as we never delete anything this iterator should remain in memory
+    std::string * addr = &(_string_storage.back()); 
+    it = _string_to_id_map.emplace(addr, _string_to_id_map.size() + 1).first;
+    _id_to_string_map.emplace(it->second, it->first);
+  }
+  return it->second;
+}
+
+size_t cmStringTable::GetStringId(const char * str)
+{
+  return GetStringId(std::string(str));
+}
+
+const std::string & cmStringTable::GetString(size_t id)
+{
+  auto it = _id_to_string_map.find(id);
+  if (it != _id_to_string_map.end()) {
+    return *it->second;
+  }
+
+  // Always return a valid string. Callers make assumptions
+  // about what they can do with the result.
+  return ""; 
+}

--- a/Source/cmStringTable.cxx
+++ b/Source/cmStringTable.cxx
@@ -4,7 +4,6 @@ file Copyright.txt or https://cmake.org/licensing for details.  */
 
 #include <list>
 #include <unordered_map>
-#include <allocators>
 
 struct string_hasher
 {

--- a/Source/cmStringTable.cxx
+++ b/Source/cmStringTable.cxx
@@ -52,7 +52,6 @@ const std::string & cmStringTable::GetString(size_t id)
     return *it->second;
   }
 
-  // Always return a valid string. Callers make assumptions
-  // about what they can do with the result.
-  return ""; 
+  static std::string empty;
+  return empty;
 }

--- a/Source/cmStringTable.h
+++ b/Source/cmStringTable.h
@@ -1,0 +1,19 @@
+/* Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
+file Copyright.txt or https://cmake.org/licensing for details.  */
+#ifndef cmStringTable_h
+#define cmStringTable_h
+
+#include <string>
+
+/** \class cmStringTable
+ * \brief A lookup table for strings used to keep duplicate strings out of memory
+ */
+class cmStringTable
+{
+public:
+  static size_t GetStringId(const std::string & str);
+  static size_t GetStringId(const char * str);
+  static const std::string & GetString(size_t id);
+};
+
+#endif

--- a/Source/cmTarget.cxx
+++ b/Source/cmTarget.cxx
@@ -378,7 +378,7 @@ cmTarget::cmTarget(std::string const& name, cmStateEnums::TargetType type,
   }
   if (this->TargetTypeValue == cmStateEnums::SHARED_LIBRARY ||
       this->TargetTypeValue == cmStateEnums::MODULE_LIBRARY) {
-    this->SetProperty("POSITION_INDEPENDENT_CODE", "True");
+    this->SetProperty("POSITION_INDEPENDENT_CODE", "True", this->Backtrace);
   }
   if (this->TargetTypeValue == cmStateEnums::SHARED_LIBRARY ||
       this->TargetTypeValue == cmStateEnums::EXECUTABLE) {
@@ -733,7 +733,8 @@ void cmTarget::AddLinkLibrary(cmMakefile& mf, const std::string& lib,
       : lib;
     this->AppendProperty(
       "LINK_LIBRARIES",
-      this->GetDebugGeneratorExpressions(libName, llt).c_str());
+      this->GetDebugGeneratorExpressions(libName, llt).c_str(),
+      mf.GetBacktrace());
   }
 
   if (cmGeneratorExpression::Find(lib) != std::string::npos ||
@@ -847,7 +848,7 @@ cmBacktraceRange cmTarget::GetLinkImplementationBacktraces() const
   return cmMakeRange(this->Internal->LinkImplementationPropertyBacktraces);
 }
 
-void cmTarget::SetProperty(const std::string& prop, const char* value)
+void cmTarget::SetProperty(const std::string& prop, const char* value, const cmListFileBacktrace & backtrace)
 {
   if (!cmTargetPropertyComputer::PassesWhitelist(
         this->GetType(), prop, this->Makefile->GetMessenger(),
@@ -899,48 +900,42 @@ void cmTarget::SetProperty(const std::string& prop, const char* value)
     this->Internal->IncludeDirectoriesBacktraces.clear();
     if (value) {
       this->Internal->IncludeDirectoriesEntries.push_back(value);
-      cmListFileBacktrace lfbt = this->Makefile->GetBacktrace();
-      this->Internal->IncludeDirectoriesBacktraces.push_back(lfbt);
+      this->Internal->IncludeDirectoriesBacktraces.push_back(backtrace);
     }
   } else if (prop == "COMPILE_OPTIONS") {
     this->Internal->CompileOptionsEntries.clear();
     this->Internal->CompileOptionsBacktraces.clear();
     if (value) {
       this->Internal->CompileOptionsEntries.push_back(value);
-      cmListFileBacktrace lfbt = this->Makefile->GetBacktrace();
-      this->Internal->CompileOptionsBacktraces.push_back(lfbt);
+      this->Internal->CompileOptionsBacktraces.push_back(backtrace);
     }
   } else if (prop == "COMPILE_FEATURES") {
     this->Internal->CompileFeaturesEntries.clear();
     this->Internal->CompileFeaturesBacktraces.clear();
     if (value) {
       this->Internal->CompileFeaturesEntries.push_back(value);
-      cmListFileBacktrace lfbt = this->Makefile->GetBacktrace();
-      this->Internal->CompileFeaturesBacktraces.push_back(lfbt);
+      this->Internal->CompileFeaturesBacktraces.push_back(backtrace);
     }
   } else if (prop == "COMPILE_DEFINITIONS") {
     this->Internal->CompileDefinitionsEntries.clear();
     this->Internal->CompileDefinitionsBacktraces.clear();
     if (value) {
       this->Internal->CompileDefinitionsEntries.push_back(value);
-      cmListFileBacktrace lfbt = this->Makefile->GetBacktrace();
-      this->Internal->CompileDefinitionsBacktraces.push_back(lfbt);
+      this->Internal->CompileDefinitionsBacktraces.push_back(backtrace);
     }
   } else if (prop == "LINK_LIBRARIES") {
     this->Internal->LinkImplementationPropertyEntries.clear();
     this->Internal->LinkImplementationPropertyBacktraces.clear();
     if (value) {
-      cmListFileBacktrace lfbt = this->Makefile->GetBacktrace();
       this->Internal->LinkImplementationPropertyEntries.push_back(value);
-      this->Internal->LinkImplementationPropertyBacktraces.push_back(lfbt);
+      this->Internal->LinkImplementationPropertyBacktraces.push_back(backtrace);
     }
   } else if (prop == "SOURCES") {
     this->Internal->SourceEntries.clear();
     this->Internal->SourceBacktraces.clear();
     if (value) {
-      cmListFileBacktrace lfbt = this->Makefile->GetBacktrace();
       this->Internal->SourceEntries.push_back(value);
-      this->Internal->SourceBacktraces.push_back(lfbt);
+      this->Internal->SourceBacktraces.push_back(backtrace);
     }
   } else if (prop == "IMPORTED_GLOBAL") {
     if (!cmSystemTools::IsOn(value)) {
@@ -967,16 +962,16 @@ void cmTarget::SetProperty(const std::string& prop, const char* value)
     this->Makefile->IssueMessage(cmake::FATAL_ERROR, e.str());
     return;
   } else {
-    this->Properties.SetProperty(prop, value);
+    this->Properties.SetProperty(prop, value, backtrace);
   }
 }
 
-void cmTarget::AppendProperty(const std::string& prop, const char* value,
+void cmTarget::AppendProperty(const std::string& prop, const char* value, const cmListFileBacktrace & backtrace,
                               bool asString)
 {
   if (!cmTargetPropertyComputer::PassesWhitelist(
         this->GetType(), prop, this->Makefile->GetMessenger(),
-        this->Makefile->GetBacktrace())) {
+        backtrace)) {
     return;
   }
   if (prop == "NAME") {
@@ -1010,42 +1005,36 @@ void cmTarget::AppendProperty(const std::string& prop, const char* value,
   if (prop == "INCLUDE_DIRECTORIES") {
     if (value && *value) {
       this->Internal->IncludeDirectoriesEntries.push_back(value);
-      cmListFileBacktrace lfbt = this->Makefile->GetBacktrace();
-      this->Internal->IncludeDirectoriesBacktraces.push_back(lfbt);
+      this->Internal->IncludeDirectoriesBacktraces.push_back(backtrace);
     }
   } else if (prop == "COMPILE_OPTIONS") {
     if (value && *value) {
       this->Internal->CompileOptionsEntries.push_back(value);
-      cmListFileBacktrace lfbt = this->Makefile->GetBacktrace();
-      this->Internal->CompileOptionsBacktraces.push_back(lfbt);
+      this->Internal->CompileOptionsBacktraces.push_back(backtrace);
     }
   } else if (prop == "COMPILE_FEATURES") {
     if (value && *value) {
       this->Internal->CompileFeaturesEntries.push_back(value);
-      cmListFileBacktrace lfbt = this->Makefile->GetBacktrace();
-      this->Internal->CompileFeaturesBacktraces.push_back(lfbt);
+      this->Internal->CompileFeaturesBacktraces.push_back(backtrace);
     }
   } else if (prop == "COMPILE_DEFINITIONS") {
     if (value && *value) {
       this->Internal->CompileDefinitionsEntries.push_back(value);
-      cmListFileBacktrace lfbt = this->Makefile->GetBacktrace();
-      this->Internal->CompileDefinitionsBacktraces.push_back(lfbt);
+      this->Internal->CompileDefinitionsBacktraces.push_back(backtrace);
     }
   } else if (prop == "LINK_LIBRARIES") {
     if (value && *value) {
-      cmListFileBacktrace lfbt = this->Makefile->GetBacktrace();
       this->Internal->LinkImplementationPropertyEntries.push_back(value);
-      this->Internal->LinkImplementationPropertyBacktraces.push_back(lfbt);
+      this->Internal->LinkImplementationPropertyBacktraces.push_back(backtrace);
     }
   } else if (prop == "SOURCES") {
-    cmListFileBacktrace lfbt = this->Makefile->GetBacktrace();
     this->Internal->SourceEntries.push_back(value);
-    this->Internal->SourceBacktraces.push_back(lfbt);
+    this->Internal->SourceBacktraces.push_back(backtrace);
   } else if (cmHasLiteralPrefix(prop, "IMPORTED_LIBNAME")) {
     this->Makefile->IssueMessage(cmake::FATAL_ERROR,
                                  prop + " property may not be APPENDed.");
   } else {
-    this->Properties.AppendProperty(prop, value, asString);
+    this->Properties.AppendProperty(prop, value, backtrace, asString);
   }
 }
 
@@ -1070,7 +1059,8 @@ void cmTarget::AppendBuildInterfaceIncludes()
       std::string(binDir ? ";" : "") + std::string(srcDir ? srcDir : "");
     if (!dirs.empty()) {
       this->AppendProperty("INTERFACE_INCLUDE_DIRECTORIES",
-                           ("$<BUILD_INTERFACE:" + dirs + ">").c_str());
+                           ("$<BUILD_INTERFACE:" + dirs + ">").c_str(),
+                           this->GetPropertyBacktrace("INTERFACE_INCLUDE_DIRECTORIES"));
     }
   }
 }
@@ -1348,6 +1338,23 @@ const char* cmTarget::GetProperty(const std::string& prop) const
   return retVal;
 }
 
+const cmListFileBacktrace & cmTarget::GetPropertyBacktrace(const std::string & prop) const
+{
+  bool haveProperty = this->Properties.HasProperty(prop);
+  if (!haveProperty) {
+    const bool chain = this->GetMakefile()->GetState()->IsPropertyChained(
+      prop, cmProperty::TARGET);
+    if (chain) {
+      return this->Makefile->GetStateSnapshot().GetDirectory().GetPropertyBacktrace(
+        prop);
+    } else {
+      return Backtrace;
+    }
+  } else {
+    return this->Properties.GetPropertyBacktrace(prop);
+  }
+}
+
 bool cmTarget::GetPropertyAsBool(const std::string& prop) const
 {
   return cmSystemTools::IsOn(this->GetProperty(prop));
@@ -1502,9 +1509,9 @@ void cmTarget::SetPropertyDefault(const std::string& property,
   var += property;
 
   if (const char* value = this->Makefile->GetDefinition(var)) {
-    this->SetProperty(property, value);
+    this->SetProperty(property, value, this->Backtrace);
   } else if (default_value) {
-    this->SetProperty(property, default_value);
+    this->SetProperty(property, default_value, this->Backtrace);
   }
 }
 

--- a/Source/cmTarget.cxx
+++ b/Source/cmTarget.cxx
@@ -713,8 +713,8 @@ void cmTarget::GetTllSignatureTraces(std::ostream& s, TLLSignature sig) const
   for (auto const& cmd : this->TLLCommands) {
     if (cmd.first == sig) {
       cmListFileContext lfc = cmd.second;
-      lfc.FilePath = converter.ConvertToRelativePath(
-        this->Makefile->GetState()->GetSourceDirectory(), lfc.FilePath);
+      lfc.UpdateFilePath(converter.ConvertToRelativePath(
+        this->Makefile->GetState()->GetSourceDirectory(), lfc.FilePath()));
       s << " * " << lfc << std::endl;
     }
   }

--- a/Source/cmTarget.cxx
+++ b/Source/cmTarget.cxx
@@ -721,7 +721,8 @@ void cmTarget::GetTllSignatureTraces(std::ostream& s, TLLSignature sig) const
 }
 
 void cmTarget::AddLinkLibrary(cmMakefile& mf, const std::string& lib,
-                              cmTargetLinkLibraryType llt)
+                              cmTargetLinkLibraryType llt,
+                              const cmListFileBacktrace & bt)
 {
   cmTarget* tgt = this->Makefile->FindTargetToUse(lib);
   {
@@ -734,7 +735,7 @@ void cmTarget::AddLinkLibrary(cmMakefile& mf, const std::string& lib,
     this->AppendProperty(
       "LINK_LIBRARIES",
       this->GetDebugGeneratorExpressions(libName, llt).c_str(),
-      mf.GetBacktrace());
+      bt);
   }
 
   if (cmGeneratorExpression::Find(lib) != std::string::npos ||

--- a/Source/cmTarget.h
+++ b/Source/cmTarget.h
@@ -140,7 +140,8 @@ public:
   void ClearDependencyInformation(cmMakefile& mf, const std::string& target);
 
   void AddLinkLibrary(cmMakefile& mf, const std::string& lib,
-                      cmTargetLinkLibraryType llt);
+                      cmTargetLinkLibraryType llt,
+                      const cmListFileBacktrace & bt);
   enum TLLSignature
   {
     KeywordTLLSignature,

--- a/Source/cmTarget.h
+++ b/Source/cmTarget.h
@@ -196,8 +196,8 @@ public:
   cmListFileBacktrace const* GetUtilityBacktrace(const std::string& u) const;
 
   ///! Set/Get a property of this target file
-  void SetProperty(const std::string& prop, const char* value);
-  void AppendProperty(const std::string& prop, const char* value,
+  void SetProperty(const std::string& prop, const char* value, const cmListFileBacktrace & backtrace);
+  void AppendProperty(const std::string& prop, const char* value, const cmListFileBacktrace & backtrace,
                       bool asString = false);
   const char* GetProperty(const std::string& prop) const;
   bool GetPropertyAsBool(const std::string& prop) const;
@@ -205,6 +205,7 @@ public:
   const char* GetComputedProperty(const std::string& prop,
                                   cmMessenger* messenger,
                                   cmListFileBacktrace const& context) const;
+  const cmListFileBacktrace & GetPropertyBacktrace(const std::string & prop) const;
 
   bool IsImported() const { return this->IsImportedTarget; }
   bool IsImportedGloballyVisible() const

--- a/Source/cmTargetCompileDefinitionsCommand.cxx
+++ b/Source/cmTargetCompileDefinitionsCommand.cxx
@@ -46,6 +46,6 @@ std::string cmTargetCompileDefinitionsCommand::Join(
 bool cmTargetCompileDefinitionsCommand::HandleDirectContent(
   cmTarget* tgt, const std::vector<std::string>& content, bool, bool)
 {
-  tgt->AppendProperty("COMPILE_DEFINITIONS", this->Join(content).c_str());
+  tgt->AppendProperty("COMPILE_DEFINITIONS", this->Join(content).c_str(), this->GetBacktrace());
   return true; // Successfully handled.
 }

--- a/Source/cmTargetDepend.h
+++ b/Source/cmTargetDepend.h
@@ -14,6 +14,7 @@ class cmGeneratorTarget;
 class cmTargetDepend
 {
   cmGeneratorTarget const* Target;
+  mutable cmListFileBacktrace Bt;
 
   // The set order depends only on the Target, so we use
   // mutable members to achieve a map with set syntax.
@@ -25,6 +26,7 @@ public:
     : Target(t)
     , Link(false)
     , Util(false)
+    , Bt()
   {
   }
   operator cmGeneratorTarget const*() const { return this->Target; }
@@ -42,8 +44,13 @@ public:
       this->Link = true;
     }
   }
+  void SetBacktrace(cmListFileBacktrace const & bt) const
+  {
+    this->Bt = bt;
+  }
   bool IsLink() const { return this->Link; }
   bool IsUtil() const { return this->Util; }
+  cmListFileBacktrace & Backtrace() const { return this->Bt; }
 };
 
 /** Unordered set of (direct) dependencies of a target. */

--- a/Source/cmTargetIncludeDirectoriesCommand.cxx
+++ b/Source/cmTargetIncludeDirectoriesCommand.cxx
@@ -82,6 +82,7 @@ void cmTargetIncludeDirectoriesCommand::HandleInterfaceContent(
   if (system) {
     std::string joined = this->Join(content);
     tgt->AppendProperty("INTERFACE_SYSTEM_INCLUDE_DIRECTORIES",
-                        joined.c_str());
+                        joined.c_str(),
+                        this->GetBacktrace());
   }
 }

--- a/Source/cmTargetLinkLibrariesCommand.cxx
+++ b/Source/cmTargetLinkLibrariesCommand.cxx
@@ -406,7 +406,7 @@ bool cmTargetLinkLibrariesCommand::HandleLibrary(const std::string& lib,
         this->Makefile->IssueMessage(cmake::FATAL_ERROR, e.str());
       }
 
-      this->Target->AddLinkLibrary(*this->Makefile, lib, llt);
+      this->Target->AddLinkLibrary(*this->Makefile, lib, llt, this->GetBacktrace());
     }
 
     if (this->CurrentProcessingState == ProcessingLinkLibraries) {

--- a/Source/cmTargetLinkLibrariesCommand.cxx
+++ b/Source/cmTargetLinkLibrariesCommand.cxx
@@ -281,7 +281,7 @@ bool cmTargetLinkLibrariesCommand::InitialPass(
        policy22Status == cmPolicies::WARN) &&
       this->CurrentProcessingState != ProcessingLinkLibraries &&
       !this->Target->GetProperty("LINK_INTERFACE_LIBRARIES")) {
-    this->Target->SetProperty("LINK_INTERFACE_LIBRARIES", "");
+    this->Target->SetProperty("LINK_INTERFACE_LIBRARIES", "", this->GetBacktrace());
   }
 
   return true;
@@ -412,7 +412,8 @@ bool cmTargetLinkLibrariesCommand::HandleLibrary(const std::string& lib,
     if (this->CurrentProcessingState == ProcessingLinkLibraries) {
       this->Target->AppendProperty(
         "INTERFACE_LINK_LIBRARIES",
-        this->Target->GetDebugGeneratorExpressions(lib, llt).c_str());
+        this->Target->GetDebugGeneratorExpressions(lib, llt).c_str(),
+        this->GetBacktrace());
       return true;
     }
     if (this->CurrentProcessingState != ProcessingKeywordPublicInterface &&
@@ -425,7 +426,8 @@ bool cmTargetLinkLibrariesCommand::HandleLibrary(const std::string& lib,
           configLib = "$<LINK_ONLY:" + configLib + ">";
         }
         this->Target->AppendProperty("INTERFACE_LINK_LIBRARIES",
-                                     configLib.c_str());
+                                     configLib.c_str(),
+                                     this->GetBacktrace());
       }
       // Not a 'public' or 'interface' library. Do not add to interface
       // property.
@@ -435,7 +437,8 @@ bool cmTargetLinkLibrariesCommand::HandleLibrary(const std::string& lib,
 
   this->Target->AppendProperty(
     "INTERFACE_LINK_LIBRARIES",
-    this->Target->GetDebugGeneratorExpressions(lib, llt).c_str());
+    this->Target->GetDebugGeneratorExpressions(lib, llt).c_str(),
+    this->GetBacktrace());
 
   const cmPolicies::PolicyStatus policy22Status =
     this->Target->GetPolicyStatusCMP0022();
@@ -460,12 +463,12 @@ bool cmTargetLinkLibrariesCommand::HandleLibrary(const std::string& lib,
     for (std::string const& dc : debugConfigs) {
       prop = "LINK_INTERFACE_LIBRARIES_";
       prop += dc;
-      this->Target->AppendProperty(prop, lib.c_str());
+      this->Target->AppendProperty(prop, lib.c_str(), this->GetBacktrace());
     }
   }
   if (llt == OPTIMIZED_LibraryType || llt == GENERAL_LibraryType) {
     // Put in the non-DEBUG configuration interfaces.
-    this->Target->AppendProperty("LINK_INTERFACE_LIBRARIES", lib.c_str());
+    this->Target->AppendProperty("LINK_INTERFACE_LIBRARIES", lib.c_str(), this->GetBacktrace());
 
     // Make sure the DEBUG configuration interfaces exist so that the
     // general one will not be used as a fall-back.
@@ -473,7 +476,7 @@ bool cmTargetLinkLibrariesCommand::HandleLibrary(const std::string& lib,
       prop = "LINK_INTERFACE_LIBRARIES_";
       prop += dc;
       if (!this->Target->GetProperty(prop)) {
-        this->Target->SetProperty(prop, "");
+        this->Target->SetProperty(prop, "", this->GetBacktrace());
       }
     }
   }

--- a/Source/cmTargetPropCommandBase.cxx
+++ b/Source/cmTargetPropCommandBase.cxx
@@ -129,11 +129,13 @@ void cmTargetPropCommandBase::HandleInterfaceContent(
   if (prepend) {
     const std::string propName = std::string("INTERFACE_") + this->Property;
     const char* propValue = tgt->GetProperty(propName);
+    auto & backtrace = tgt->GetPropertyBacktrace(propName);
     const std::string totalContent = this->Join(content) +
       (propValue ? std::string(";") + propValue : std::string());
-    tgt->SetProperty(propName, totalContent.c_str());
+    tgt->SetProperty(propName, totalContent.c_str(), backtrace);
   } else {
     tgt->AppendProperty("INTERFACE_" + this->Property,
-                        this->Join(content).c_str());
+                        this->Join(content).c_str(),
+                        this->GetBacktrace());
   }
 }

--- a/Source/cmTargetSourcesCommand.cxx
+++ b/Source/cmTargetSourcesCommand.cxx
@@ -35,6 +35,6 @@ std::string cmTargetSourcesCommand::Join(
 bool cmTargetSourcesCommand::HandleDirectContent(
   cmTarget* tgt, const std::vector<std::string>& content, bool, bool)
 {
-  tgt->AppendProperty("SOURCES", this->Join(content).c_str());
+  tgt->AppendProperty("SOURCES", this->Join(content).c_str(), this->GetBacktrace());
   return true; // Successfully handled.
 }

--- a/Source/cmTest.cxx
+++ b/Source/cmTest.cxx
@@ -53,11 +53,11 @@ bool cmTest::GetPropertyAsBool(const std::string& prop) const
 
 void cmTest::SetProperty(const std::string& prop, const char* value)
 {
-  this->Properties.SetProperty(prop, value);
+  this->Properties.SetProperty(prop, value, GetBacktrace());
 }
 
 void cmTest::AppendProperty(const std::string& prop, const char* value,
                             bool asString)
 {
-  this->Properties.AppendProperty(prop, value, asString);
+  this->Properties.AppendProperty(prop, value, GetBacktrace(), asString);
 }

--- a/Source/cmVisualStudio10TargetGenerator.cxx
+++ b/Source/cmVisualStudio10TargetGenerator.cxx
@@ -210,9 +210,12 @@ void cmVisualStudio10TargetGenerator::Generate()
   }
   // Tell the global generator the name of the project file
   this->GeneratorTarget->Target->SetProperty("GENERATOR_FILE_NAME",
-                                             this->Name.c_str());
-  this->GeneratorTarget->Target->SetProperty(
-    "GENERATOR_FILE_NAME_EXT", this->ProjectFileExtension.c_str());
+                                             this->Name.c_str(),
+                                             this->GeneratorTarget->Target->GetBacktrace());
+  this->GeneratorTarget->Target->SetProperty("GENERATOR_FILE_NAME_EXT",
+                                             this->ProjectFileExtension.c_str(),
+                                             this->GeneratorTarget->Target->GetBacktrace());
+
   if (this->GeneratorTarget->GetType() <= cmStateEnums::OBJECT_LIBRARY) {
     if (!this->ComputeClOptions()) {
       return;

--- a/Source/cmWhileCommand.cxx
+++ b/Source/cmWhileCommand.cxx
@@ -51,7 +51,7 @@ bool cmWhileFunctionBlocker::IsFunctionBlocked(const cmListFileFunction& lff,
 
       cmCommandContext commandContext;
       commandContext.Line = execContext.Line;
-      commandContext.Name = execContext.Name;
+      commandContext.Name = execContext.Name();
 
       cmConditionEvaluator conditionEvaluator(mf, this->GetStartingContext(),
                                               mf.GetBacktrace(commandContext));

--- a/Source/cmake.cxx
+++ b/Source/cmake.cxx
@@ -139,6 +139,7 @@ void cmWarnUnusedCliWarning(const std::string& variable, int /*unused*/,
 
 cmake::cmake(Role role)
 {
+  this->RoleVal = role;
   this->Trace = false;
   this->TraceExpand = false;
   this->WarnUninitialized = false;

--- a/Source/cmake.cxx
+++ b/Source/cmake.cxx
@@ -569,7 +569,7 @@ bool cmake::FindPackage(const std::vector<std::string>& args)
     const char* targetName = "dummy";
     std::vector<std::string> srcs;
     cmTarget* tgt = mf->AddExecutable(targetName, srcs, true);
-    tgt->SetProperty("LINKER_LANGUAGE", language.c_str());
+    tgt->SetProperty("LINKER_LANGUAGE", language.c_str(), tgt->GetBacktrace());
 
     std::string libs = mf->GetSafeDefinition("PACKAGE_LIBRARIES");
     std::vector<std::string> libList;
@@ -1149,7 +1149,7 @@ int cmake::HandleDeleteCacheVariables(const std::string& var)
   std::vector<std::string> argsSplit;
   cmSystemTools::ExpandListArgument(std::string(var), argsSplit, true);
   // erase the property to avoid infinite recursion
-  this->State->SetGlobalProperty("__CMAKE_DELETE_CACHE_CHANGE_VARS_", "");
+  this->State->SetGlobalProperty("__CMAKE_DELETE_CACHE_CHANGE_VARS_", "", cmListFileBacktrace::Empty());
   if (this->State->GetIsInTryCompile()) {
     return 0;
   }
@@ -2098,15 +2098,15 @@ void cmake::GenerateGraphViz(const char* fileName) const
 #endif
 }
 
-void cmake::SetProperty(const std::string& prop, const char* value)
+void cmake::SetProperty(const std::string& prop, const char* value, const cmListFileBacktrace & backtrace)
 {
-  this->State->SetGlobalProperty(prop, value);
+  this->State->SetGlobalProperty(prop, value, backtrace);
 }
 
-void cmake::AppendProperty(const std::string& prop, const char* value,
+void cmake::AppendProperty(const std::string& prop, const char* value, const cmListFileBacktrace & backtrace,
                            bool asString)
 {
-  this->State->AppendGlobalProperty(prop, value, asString);
+  this->State->AppendGlobalProperty(prop, value, backtrace, asString);
 }
 
 const char* cmake::GetProperty(const std::string& prop)

--- a/Source/cmake.cxx
+++ b/Source/cmake.cxx
@@ -575,7 +575,7 @@ bool cmake::FindPackage(const std::vector<std::string>& args)
     std::vector<std::string> libList;
     cmSystemTools::ExpandListArgument(libs, libList);
     for (std::string const& lib : libList) {
-      tgt->AddLinkLibrary(*mf, lib, GENERAL_LibraryType);
+      tgt->AddLinkLibrary(*mf, lib, GENERAL_LibraryType, mf->GetBacktrace());
     }
 
     std::string buildType = mf->GetSafeDefinition("CMAKE_BUILD_TYPE");

--- a/Source/cmake.h
+++ b/Source/cmake.h
@@ -291,8 +291,8 @@ public:
   void GetGeneratorDocumentation(std::vector<cmDocumentationEntry>&);
 
   ///! Set/Get a property of this target file
-  void SetProperty(const std::string& prop, const char* value);
-  void AppendProperty(const std::string& prop, const char* value,
+  void SetProperty(const std::string& prop, const char* value, const cmListFileBacktrace & backtrace);
+  void AppendProperty(const std::string& prop, const char* value, const cmListFileBacktrace & backtrace,
                       bool asString = false);
   const char* GetProperty(const std::string& prop);
   bool GetPropertyAsBool(const std::string& prop);

--- a/Source/cmake.h
+++ b/Source/cmake.h
@@ -61,9 +61,10 @@ class cmake
 public:
   enum Role
   {
-    RoleInternal, // no commands
-    RoleScript,   // script commands
-    RoleProject   // all commands
+    RoleInternal = 1, // no commands
+    RoleScript   = 2, // script commands
+    RoleProject  = 4, // all commands
+	RoleServer   = 8, // server mode
   };
 
   enum MessageType
@@ -436,6 +437,7 @@ public:
     this->CurrentSnapshot = snapshot;
   }
   cmStateSnapshot GetCurrentSnapshot() const { return this->CurrentSnapshot; }
+  bool IsServerMode() const { return this->RoleVal && Role::RoleServer; }
 
 protected:
   void RunCheckForUnusedVariables();
@@ -517,6 +519,7 @@ private:
   cmMessenger* Messenger;
 
   std::vector<std::string> TraceOnlyThisSources;
+  Role RoleVal;
 
   void UpdateConversionPathTable();
 

--- a/Tests/Server/tc_ctestinfo.json
+++ b/Tests/Server/tc_ctestinfo.json
@@ -17,6 +17,10 @@
 
 { "message": "TestInfo:" },
 { "send": { "type": "ctestInfo", "cookie":"ctestInfo" } },
+{ "validateTestInfo": { "hasTests": true, "hasTraces" :  false, "expectedTest": "dummytest" } },
+
+{ "message": "TestInfo with traces:" },
+{ "send": { "type": "ctestInfo", "cookie":"ctestInfo", "includeTraces" :  true } },
 { "validateTestInfo": { "hasTests": true, "hasTraces" :  true, "expectedTest": "dummytest" } },
 
 { "message": "Everything ok." }


### PR DESCRIPTION
Add direct dependencies for targets
Revamp backtrace storage to be more compact (don't keep dupes of strings)

Perf changes are negligible (seems faster and slower based on cmake project by 4 or 5%)
Memory changes are negligible too.

