### PR TITLE
add missing cmStringTable to build

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -402,6 +402,7 @@ CMAKE_CXX_SOURCES="\
   cmStringCommand \
   cmSubdirCommand \
   cmSystemTools \
+  cmStringTable \
   cmTarget \
   cmTargetCompileDefinitionsCommand \
   cmTargetCompileFeaturesCommand \


### PR DESCRIPTION
add cmStringTable TU to build when using bootstrap/configure