### PR TITLE
ctest --show-only=json-v1 support

### DIFF
--- a/Help/manual/ctest.1.rst
+++ b/Help/manual/ctest.1.rst
@@ -109,19 +109,22 @@ Options
 
  This option tells CTest to write all its output to a log file.
 
-``-N,--show-only``
+``-N,--show-only[=<format>]``
  Disable actual execution of tests.
 
  This option tells CTest to list the tests that would be run but not
  actually run them.  Useful in conjunction with the ``-R`` and ``-E``
  options.
 
-``--show-as-json[=<version>]``
- Dump the test information in json format. Optionally specify a major
- version number. Defaults to 1 if not passed. Dumps the highest known
- minor version associated with the requested major version.
+ ``<format>`` can be one of the following values.
 
- See `Show as json Object Model`_.
+   ``human``
+     Human-friendly output.  This is not guaranteed to be stable.
+     This is the default.
+
+   ``json-v1``
+     Dump the test information in JSON format.
+     See `Show as JSON Object Model`_.
 
 ``-L <regex>, --label-regex <regex>``
  Run tests with labels matching regular expression.
@@ -345,7 +348,10 @@ See `Build and Test Mode`_.
 Show as JSON Object Model
 =========================
 
-When the ``--show-as-json`` command line option is given, the test
+Show as JSON Object Model
+=========================
+
+When the ``--show-only=json-v1`` command line option is given, the test
 information is output in JSON format.  Version 1.0 of the JSON object
 model is defined as follows:
 

--- a/Source/cmCTest.cxx
+++ b/Source/cmCTest.cxx
@@ -1936,25 +1936,18 @@ bool cmCTest::HandleCommandLineArguments(size_t& i,
   if (this->CheckArgument(arg, "-N", "--show-only")) {
     this->ShowOnly = true;
   }
-  if (cmSystemTools::StringStartsWith(arg.c_str(), "--show-as-json")) {
-    // Force show only mode so the tests don't run.
+  if (cmSystemTools::StringStartsWith(arg.c_str(), "--show-only=")) {
     this->ShowOnly = true;
-    // Force quiet mode so the only output is the json object model.
-    this->Quiet = true;
-    this->OutputAsJson = true;
-    this->OutputAsJsonVersion = 1;
 
-    // Check if a specific version is requested
-    std::string argWithVersion = "--show-as-json=";
-    if (cmSystemTools::StringStartsWith(arg.c_str(), argWithVersion.c_str())) {
-      std::string version = arg.substr(argWithVersion.length());
-      this->OutputAsJsonVersion = atoi(version.c_str());
-    }
-
-	if (this->OutputAsJsonVersion != 1) {
-      errormsg = "'--show-as-json[=<version>]' error, version must be 1 '" +
-        args[i] + "'";
-      return false;
+    // Check if a specific format is requested. Defaults to human readable
+    // text.
+    std::string argWithFormat = "--show-only=";
+    std::string format = arg.substr(argWithFormat.length());
+    if (format == "json-v1") {
+      // Force quiet mode so the only output is the json object model.
+      this->Quiet = true;
+      this->OutputAsJson = true;
+      this->OutputAsJsonVersion = 1;
     }
   }
 

--- a/Source/ctest.cxx
+++ b/Source/ctest.cxx
@@ -46,11 +46,10 @@ static const char* cmDocumentationOptions[][2] = {
     "given number of jobs." },
   { "-Q,--quiet", "Make ctest quiet." },
   { "-O <file>, --output-log <file>", "Output to log file" },
-  { "-N,--show-only", "Disable actual execution of tests." },
-  { "--show-as-json[=<version>]",
-    "Dump the test information in json format. Optionally specify a major "
-    "version number. Defaults to 1 if not passed. Dumps the highest known "
-    "minor version associated with the requested major version." },
+  { "-N,--show-only[=format]",
+    "Disable actual execution of tests. The optional 'format' defines the "
+    "format of the test information and can be 'human' for the current text "
+    "format or 'json-v1' for json format. Defaults to 'human'." },
   { "-L <regex>, --label-regex <regex>",
     "Run tests with labels matching "
     "regular expression." },


### PR DESCRIPTION
Changing the format to what will appear in upstream cmake 3.14