### PR TITLE
Support Named Pipe for DAP Traffics on Windows

### DIFF
--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -185,6 +185,8 @@ add_library(
   cmDebuggerBreakpointManager.h
   cmDebuggerExceptionManager.cxx
   cmDebuggerExceptionManager.h
+  cmDebuggerAdapterFactory.cxx
+  cmDebuggerAdapterFactory.h
   cmDebuggerProtocol.cxx
   cmDebuggerProtocol.h
   cmDebuggerSourceBreakpoint.cxx
@@ -759,6 +761,16 @@ add_library(
 
   bindexplib.cxx
   )
+
+if(WIN32)
+  # Use the Windows implementation.
+  target_sources(
+    CMakeLib
+    PRIVATE
+      cmDebuggerNamedPipeWin32.cxx
+    )
+endif()
+
 target_include_directories(
   CMakeLib
   PUBLIC

--- a/Source/cmDebuggerAdapterFactory.cxx
+++ b/Source/cmDebuggerAdapterFactory.cxx
@@ -1,0 +1,56 @@
+/* Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
+   file Copyright.txt or https://cmake.org/licensing for details.  */
+#include "cmDebuggerAdapterFactory.h"
+
+#include <iostream>
+
+#ifdef _WIN32
+#  include <fcntl.h> // _O_BINARY
+#  include <io.h>    // _setmode
+#endif
+
+#include "cmDebuggerAdapter.h"
+
+namespace cmDebugger {
+extern std::shared_ptr<dap::ReaderWriter> CreateDebuggerNamedPipe(
+  std::string const& name);
+
+std::shared_ptr<cmDebuggerAdapter> cmDebuggerAdapterFactory::CreateAdapter(
+  std::string namedPipeIfAny, std::string dapLogFileIfAny)
+{
+  std::shared_ptr<dap::Reader> input;
+  std::shared_ptr<dap::Writer> output;
+
+  if (namedPipeIfAny.empty()) {
+#if defined(_WIN32)
+    // Change from text mode to binary mode for all Windows OS.
+    // This ensures sequences of \r\n are not changed to \n.
+    _setmode(_fileno(stdin), _O_BINARY);
+    _setmode(_fileno(stdout), _O_BINARY);
+#endif
+    input = dap::file(stdin, false);
+    output = dap::file(stdout, false);
+  } else {
+#if defined(_WIN32)
+    std::shared_ptr<dap::ReaderWriter> pipe =
+      CreateDebuggerNamedPipe(namedPipeIfAny);
+
+    if (pipe->isOpen() == false) {
+      std::cerr << "Error: Failed to create named pipe " << namedPipeIfAny
+                << std::endl;
+      return nullptr;
+    }
+
+    input = pipe;
+    output = pipe;
+#else
+    std::cerr << "Error: Named pipe is not currently supported!" << std::endl;
+    return nullptr;
+#endif
+  }
+
+  return std::make_shared<cmDebugger::cmDebuggerAdapter>(input, output,
+                                                         dapLogFileIfAny);
+}
+
+} // namespace cmDebugger

--- a/Source/cmDebuggerAdapterFactory.h
+++ b/Source/cmDebuggerAdapterFactory.h
@@ -1,0 +1,21 @@
+/* Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
+   file Copyright.txt or https://cmake.org/licensing for details.  */
+#pragma once
+
+#include "cmConfigure.h" // IWYU pragma: keep
+
+#include <memory>
+#include <string>
+
+namespace cmDebugger {
+
+class cmDebuggerAdapter;
+
+class cmDebuggerAdapterFactory
+{
+public:
+  static std::shared_ptr<cmDebuggerAdapter> CreateAdapter(
+    std::string namedPipeIfAny, std::string dapLogFileIfAny);
+};
+
+} // namespace cmDebugger

--- a/Source/cmDebuggerNamedPipeWin32.cxx
+++ b/Source/cmDebuggerNamedPipeWin32.cxx
@@ -1,0 +1,140 @@
+/* Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
+   file Copyright.txt or https://cmake.org/licensing for details.  */
+#include <atomic>
+#include <mutex>
+#include <string>
+
+#include <windows.h>
+
+#include <cm3p/cppdap/io.h>
+
+#include "cmsys/Encoding.hxx"
+
+namespace cmDebugger {
+
+class cmDebuggerNamedPipe : public dap::ReaderWriter
+{
+  std::mutex ReadMutex;
+  std::mutex WriteMutex;
+  std::atomic<bool> closed = { false };
+  HANDLE Pipe;
+  OVERLAPPED ReadOverlap;
+  OVERLAPPED WriteOverlap;
+
+public:
+  cmDebuggerNamedPipe(std::string const& name)
+  {
+    Pipe = CreateFileW(cmsys::Encoding::ToWide(name.c_str()).c_str(),
+                       GENERIC_READ | GENERIC_WRITE,
+                       0,                    // no sharing
+                       NULL,                 // default security attributes
+                       OPEN_EXISTING,        // pipe exists
+                       FILE_FLAG_OVERLAPPED, // default attributes
+                       NULL                  // no template file
+    );
+
+    ZeroMemory(&ReadOverlap, sizeof(OVERLAPPED));
+    ZeroMemory(&WriteOverlap, sizeof(OVERLAPPED));
+
+    if (Pipe == INVALID_HANDLE_VALUE) {
+      closed.store(true);
+      return;
+    }
+
+    ReadOverlap.hEvent = CreateEvent(NULL,   // default security attribute
+                                     TRUE,   // manual-reset event
+                                     FALSE,  // initial state
+                                     NULL);  // unnamed event object
+    WriteOverlap.hEvent = CreateEvent(NULL,  // default security attribute
+                                      TRUE,  // manual-reset event
+                                      FALSE, // initial state
+                                      NULL); // unnamed event object
+  }
+
+  cmDebuggerNamedPipe(HANDLE pipe)
+    : Pipe(pipe)
+  {
+    ZeroMemory(&ReadOverlap, sizeof(OVERLAPPED));
+    ReadOverlap.hEvent = CreateEvent(NULL,  // default security attribute
+                                     TRUE,  // manual-reset event
+                                     FALSE, // initial state
+                                     NULL); // unnamed event object
+    ZeroMemory(&WriteOverlap, sizeof(OVERLAPPED));
+    WriteOverlap.hEvent = CreateEvent(NULL,  // default security attribute
+                                      TRUE,  // manual-reset event
+                                      FALSE, // initial state
+                                      NULL); // unnamed event object
+  }
+
+  ~cmDebuggerNamedPipe() { close(); }
+
+  bool isOpen() override { return !closed; }
+
+  void close() override
+  {
+    if (!closed.exchange(true)) {
+      CloseHandle(Pipe);
+      CloseHandle(ReadOverlap.hEvent);
+      CloseHandle(WriteOverlap.hEvent);
+    }
+  }
+
+  size_t read(void* buffer, size_t n) override
+  {
+    std::unique_lock<std::mutex> lock(ReadMutex);
+    auto out = reinterpret_cast<char*>(buffer);
+    for (size_t i = 0; i < n; i++) {
+      DWORD bytesRead;
+      BOOL success =
+        ReadFile(Pipe, &out[i], sizeof(out[i]), &bytesRead, &ReadOverlap);
+      if (!success && GetLastError() != ERROR_IO_PENDING) {
+        return i;
+      }
+
+      success = GetOverlappedResult(Pipe, &ReadOverlap, &bytesRead, TRUE);
+
+      if (!success) {
+        return i;
+      }
+    }
+
+    return n;
+  }
+
+  bool write(const void* buffer, size_t n) override
+  {
+    std::unique_lock<std::mutex> lock(WriteMutex);
+    DWORD totalBytesWritten = 0;
+    DWORD bytesWritten;
+    while (totalBytesWritten < n) {
+      BOOL success =
+        WriteFile(Pipe, &(static_cast<const char*>(buffer)[totalBytesWritten]),
+                  n, &bytesWritten, &WriteOverlap);
+      if (!success && GetLastError() != ERROR_IO_PENDING) {
+        return false;
+      }
+
+      // Wait for the write to complete
+      success = GetOverlappedResult(Pipe, &WriteOverlap, &bytesWritten, TRUE);
+      if (!success) {
+        return false;
+      }
+      totalBytesWritten += bytesWritten;
+    }
+
+    return true;
+  }
+};
+
+
+std::shared_ptr<dap::ReaderWriter> CreateDebuggerNamedPipe(std::string const& name)
+{
+  return std::make_shared<cmDebuggerNamedPipe>(name);
+}
+
+std::shared_ptr<dap::ReaderWriter> CreateDebuggerNamedPipe(HANDLE pipe)
+{
+  return std::make_shared<cmDebuggerNamedPipe>(pipe);
+}
+
+} // namespace cmDebugger

--- a/Source/cmExecProgramCommand.cxx
+++ b/Source/cmExecProgramCommand.cxx
@@ -6,12 +6,12 @@
 
 #include "cmsys/Process.h"
 
-#include "cmake.h"
 #include "cmExecutionStatus.h"
 #include "cmMakefile.h"
 #include "cmProcessOutput.h"
 #include "cmStringAlgorithms.h"
 #include "cmSystemTools.h"
+#include "cmake.h"
 
 using Encoding = cmProcessOutput::Encoding;
 
@@ -184,15 +184,11 @@ bool RunCommand(std::string command, std::string& output, int& retVal,
     return false;
   }
 
-    if (status.GetMakefile().GetCMakeInstance()->GetDebuggerOn()) {
-    // In debugger mode, we use stdin and stdout to communicate with IDE,
-    // the cppdap thread would fget stdin as fast as it can.
-    // Most of the time, fget would be blocked, which seems to be blocking
-    // child processes that have shared stdin from completing until some
-    // data coming from the IDE and unblock fget, then the child process
-    // can complete.
-    //
-    // As a workaround until I discuss with Kitware, we will pass no stdin.
+  if (status.GetMakefile().GetCMakeInstance()->GetDebuggerOn() &&
+      status.GetMakefile().GetCMakeInstance()->GetDebuggerPipe().empty()) {
+    // If no named pipe is provided in debugger mode, stdin and stdout are
+    // used instead for DAP traffics. To not block child processes from
+    // completing, we will pass no stdin as a workaround.
     cmsysProcess_SetPipeShared(cp, cmsysProcess_Pipe_STDIN, 0);
   }
 

--- a/Source/cmake.h
+++ b/Source/cmake.h
@@ -780,12 +780,13 @@ private:
 
 public:
   bool GetDebuggerOn() const { return this->DebuggerOn; }
+  std::string GetDebuggerPipe() const { return this->DebuggerPipe; }
   std::string GetDebuggerDapLogFile() const
   {
     return this->DebuggerDapLogFile;
   }
   void SetDebuggerOn(bool b) { this->DebuggerOn = b; }
-  void StartDebuggerIfEnabled();
+  bool StartDebuggerIfEnabled();
   void StopDebuggerIfNeeded(int exitCode);
   std::shared_ptr<cmDebugger::cmDebuggerAdapter> GetDebugAdapter()
     const noexcept
@@ -796,6 +797,7 @@ public:
 private:
   std::shared_ptr<cmDebugger::cmDebuggerAdapter> DebugAdapter;
   bool DebuggerOn = false;
+  std::string DebuggerPipe;
   std::string DebuggerDapLogFile;
 };
 

--- a/Tests/CMakeLib/CMakeLists.txt
+++ b/Tests/CMakeLib/CMakeLists.txt
@@ -40,6 +40,10 @@ if (CMake_TEST_FILESYSTEM_PATH OR NOT CMake_HAVE_CXX_FILESYSTEM)
   list(APPEND CMakeLib_TESTS testCMFilesystemPath.cxx)
 endif()
 
+if(WIN32)
+  list(APPEND CMakeLib_TESTS testCMDebuggerAdapterFactory.cxx)
+endif()
+
 add_executable(testUVProcessChainHelper testUVProcessChainHelper.cxx)
 
 set(testRST_ARGS ${CMAKE_CURRENT_SOURCE_DIR})

--- a/Tests/CMakeLib/testCMDebuggerAdapterFactory.cxx
+++ b/Tests/CMakeLib/testCMDebuggerAdapterFactory.cxx
@@ -1,22 +1,30 @@
 /* Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
    file Copyright.txt or https://cmake.org/licensing for details.  */
-
 #include <chrono>
 #include <future>
 #include <iostream>
 #include <string>
 #include <thread>
 
+#include <Windows.h>
+
 #include <stddef.h>
 
+#include "cmsys/Encoding.hxx"
+
 #include "cmDebuggerAdapter.h"
+#include "cmDebuggerAdapterFactory.h"
 #include "cmDebuggerProtocol.h"
 #include "cmStateSnapshot.h"
 #include "cmVersionConfig.h"
 
 #include "testCommon.h"
 
-bool testBasicProtocol()
+namespace cmDebugger {
+extern std::shared_ptr<dap::ReaderWriter> CreateDebuggerNamedPipe(HANDLE pipe);
+}
+
+bool testCMDebuggerAdapterFactoryWindows()
 {
   std::promise<bool> debuggerAdapterInitializedPromise;
   std::future<bool> debuggerAdapterInitializedFuture =
@@ -26,9 +34,8 @@ bool testBasicProtocol()
   std::atomic<bool> terminatedEventReceived = false;
   std::atomic<bool> threadStarted = false;
   std::atomic<bool> threadExited = false;
+  std::string namedPipe = "\\\\.\\pipe\\LOCAL\\CMakeDebuggerPipe2";
 
-  std::shared_ptr<dap::ReaderWriter> client2Debugger = dap::pipe();
-  std::shared_ptr<dap::ReaderWriter> debugger2Client = dap::pipe();
   std::unique_ptr<dap::Session> client = dap::Session::create();
   client->registerHandler([&](const dap::InitializedEvent& e) {
     initializedEventReceived.store(true);
@@ -46,15 +53,27 @@ bool testBasicProtocol()
     }
   });
 
-  client->bind(debugger2Client, client2Debugger);
+  HANDLE pipe = CreateNamedPipeW(
+    cmsys::Encoding::ToWide(namedPipe.c_str()).c_str(), // pipe name
+    PIPE_ACCESS_DUPLEX | FILE_FLAG_OVERLAPPED,          // pipe mode
+    PIPE_TYPE_BYTE | PIPE_WAIT,                         // blocking mode
+    1,         // max number of instances
+    1024 * 16, // output buffer size
+    1024 * 16, // input buffer size
+    0,         // default timeout
+    NULL       // default security attributes
+  );
+  ASSERT_TRUE(pipe != INVALID_HANDLE_VALUE);
+  std::shared_ptr<dap::ReaderWriter> client2Debugger =
+    cmDebugger::CreateDebuggerNamedPipe(pipe);
 
   std::thread debuggerThread([&]() {
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+
     std::shared_ptr<cmDebugger::cmDebuggerAdapter> debuggerAdapter =
-      std::make_shared<cmDebugger::cmDebuggerAdapter>(client2Debugger,
-                                                      debugger2Client, "");
+      cmDebugger::cmDebuggerAdapterFactory::CreateAdapter(namedPipe, {});
 
     debuggerAdapterInitializedPromise.set_value(true);
-
     debuggerAdapter->ReportExitCode(0);
 
     // Give disconnectResponse some time to be received before
@@ -64,8 +83,32 @@ bool testBasicProtocol()
     return 0;
   });
 
+  OVERLAPPED connectOverlap;
+  ZeroMemory(&connectOverlap, sizeof(OVERLAPPED));
+  connectOverlap.hEvent = CreateEvent(NULL,  // default security attribute
+                                      TRUE,  // manual-reset event
+                                      FALSE, // initial state
+                                      NULL); // unnamed event object
+  BOOL success = ConnectNamedPipe(pipe, &connectOverlap);
+  if (!success && GetLastError() != ERROR_IO_PENDING) {
+    std::cout << "Error connecting to named pipe: " << GetLastError()
+              << std::endl;
+    return 1;
+  }
+
+  DWORD unused;
+  success = GetOverlappedResult(pipe, &connectOverlap, &unused, TRUE);
+  if (!success) {
+    std::cout << "Error connecting to named pipe: " << GetLastError()
+              << std::endl;
+  }
+
+  client->bind(client2Debugger, client2Debugger);
+
   dap::CMakeInitializeRequest initializeRequest;
-  auto initializeResponse = client->send(initializeRequest).get();
+  auto response = client->send(initializeRequest);
+  auto initializeResponse = response.get();
+  ASSERT_TRUE(!initializeResponse.error);
   ASSERT_TRUE(initializeResponse.response.cmakeVersion.full == CMake_VERSION);
   ASSERT_TRUE(initializeResponse.response.cmakeVersion.major ==
               CMake_VERSION_MAJOR);
@@ -76,7 +119,6 @@ bool testBasicProtocol()
   ASSERT_TRUE(initializeResponse.response.supportsExceptionInfoRequest);
   ASSERT_TRUE(
     initializeResponse.response.exceptionBreakpointFilters.has_value());
-
   dap::LaunchRequest launchRequest;
   auto launchResponse = client->send(launchRequest).get();
   ASSERT_TRUE(!launchResponse.error);
@@ -103,9 +145,9 @@ bool testBasicProtocol()
   return true;
 }
 
-int testCMDebuggerAdapter(int, char*[])
+int testCMDebuggerAdapterFactory(int, char*[])
 {
   return runTests(std::vector<std::function<bool()>>{
-    testBasicProtocol,
+    testCMDebuggerAdapterFactoryWindows,
   });
 }

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -3637,4 +3637,8 @@ if(BUILD_TESTING)
       COMMENT "Removing test build directories."
       )
   endif()
+
+  if(WIN32)
+    add_subdirectory(Debugger)
+  endif()
 endif()

--- a/Tests/Debugger/CMakeLists.txt
+++ b/Tests/Debugger/CMakeLists.txt
@@ -1,0 +1,22 @@
+project ("Debugger")
+
+add_executable (TestDebuggerNamedPipe "TestDebuggerNamedPipe.cxx" )
+target_link_libraries(TestDebuggerNamedPipe CMakeLib CTestLib)
+
+
+if(DEFINED CMAKE_BUILD_TYPE)
+  set(SourceDir "${CMAKE_CURRENT_SOURCE_DIR}/SampleProject")
+  set(BinDir "${CMAKE_CURRENT_BINARY_DIR}/SampleProject")
+  set(NamePipe "\\\\\\\\.\\\\pipe\\\\LOCAL\\\\CMakeDebuggerPipe1")
+
+  # It seems that ${CMAKE_CMAKE_COMMAND}, when passing as an argument to a test,
+  # is not properly expanded with multi-config generators for some reason. As a
+  # result, ${CMAKE_CMAKE_COMMAND} isn't pointing to a valid location, i.e. missing
+  # the build-config in the path.
+  # As a workaroudn, we will add this test for single-configuration generators only.
+  add_test(TestDebuggerNamedPipe
+    ${CMAKE_CURRENT_BINARY_DIR}/TestDebuggerNamedPipe.exe ${NamePipe}
+    ${CMAKE_CMAKE_COMMAND} ${SourceDir} ${BinDir} 5000
+    )
+  set_tests_properties(TestDebuggerNamedPipe PROPERTIES TIMEOUT 5)
+endif()

--- a/Tests/Debugger/SampleProject/CMakeLists.txt
+++ b/Tests/Debugger/SampleProject/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required (VERSION 3.8)
+
+project(ExecuteProcessProject NONE)
+
+message("Hello CMake Debugger")
+
+

--- a/Tests/Debugger/TestDebuggerNamedPipe.cxx
+++ b/Tests/Debugger/TestDebuggerNamedPipe.cxx
@@ -1,0 +1,205 @@
+/* Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
+   file Copyright.txt or https://cmake.org/licensing for details.  */
+
+#ifdef _WIN32
+#  include <Windows.h>
+#endif
+
+#include <chrono>
+#include <cstdio>
+#include <iostream>
+#include <regex>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <cm3p/cppdap/io.h>
+
+#include "cmsys/Encoding.hxx"
+
+#include "cmSystemTools.h"
+namespace cmDebugger {
+extern std::shared_ptr<dap::ReaderWriter> CreateDebuggerNamedPipe(HANDLE pipe);
+}
+
+static void sendCommands(std::shared_ptr<dap::ReaderWriter> const& debugger,
+                         int delayMs,
+                         std::vector<std::string> const& initCommands)
+{
+  for (auto& command : initCommands) {
+    std::string contentLength = "Content-Length:";
+    contentLength += std::to_string(command.size()) + "\r\n\r\n";
+    debugger->write(contentLength.c_str(), contentLength.size());
+    if (!debugger->write(command.c_str(), command.size())) {
+      std::cout << "debugger write error: " << GetLastError() << std::endl;
+      break;
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(delayMs));
+  }
+}
+
+/** \brief Test CMake debugger named pipe.
+ *
+ * Test CMake debugger named pipe by
+ * 1. Create a named pipe for DAP traffic between the client and the debugger.
+ * 2. Create a client thread to wait for the debugger connection.
+ *    - Once the debugger is connected, send the minimum required commands to
+ *      get debugger going.
+ *    - Wait for the CMake to complete the cache generation
+ *    - Send the disconnect command.
+ *    - Read and store the debugger's responses for validation.
+ * 3. Run the CMake command with debugger on and wait for it to complete.
+ * 4. Validate the response to ensure we are getting the expected responses.
+ *
+ */
+int main(int argc, char* argv[])
+{
+  if (argc < 5) {
+    std::cout
+      << "Usage: TestDebuggerNamedPipe <NamePipe> <CMakePath> <SourceFolder> "
+         "<OutputFolder> <TimeoutMs>"
+      << std::endl;
+    return 1;
+  }
+
+  std::string namedPipe = argv[1];
+  std::string cmakeCommand = std::string(argv[2]) +
+    " --debugger --debugger-pipe " + namedPipe + " " + argv[3];
+
+  int timeout = std::stoi(argv[5]);
+  if (!(CreateDirectory(argv[4], NULL) ||
+        ERROR_ALREADY_EXISTS == GetLastError())) {
+    std::cout << "Error creating output folder " << GetLastError()
+              << std::endl;
+    return -1;
+  }
+
+  HANDLE pipe = CreateNamedPipeW(
+    cmsys::Encoding::ToWide(namedPipe.c_str()).c_str(), // pipe name
+    PIPE_ACCESS_DUPLEX | FILE_FLAG_OVERLAPPED,          // pipe mode
+    PIPE_TYPE_BYTE | PIPE_WAIT,                         // blocking mode
+    1,         // max number of instances
+    1024 * 16, // output buffer size
+    1024 * 16, // input buffer size
+    0,         // default timeout
+    NULL       // default security attributes
+  );
+
+  if (pipe == INVALID_HANDLE_VALUE) {
+    std::cout << "Error creating named pipe" << std::endl;
+    return -1;
+  }
+
+  // Capture debugger response stream.
+  std::stringstream debuggerResponseStream;
+
+  // Start the debugger client process.
+  std::thread clientThread([&]() {
+    std::cout << "Waiting for debugger connection" << std::endl;
+    if (ConnectNamedPipe(pipe, NULL) == FALSE) {
+      std::cout << "Error connecting to named pipe: " << GetLastError()
+                << std::endl;
+      return -1;
+    }
+
+    std::shared_ptr<dap::ReaderWriter> debugger =
+      cmDebugger::CreateDebuggerNamedPipe(pipe);
+
+    // Send init commands to get debugger going.
+    sendCommands(
+      debugger, 400,
+      { "{\"arguments\":{\"adapterID\":\"\"},\"command\":\"initialize\","
+        "\"seq\":"
+        "1,\"type\":\"request\"}",
+        "{\"arguments\":{},\"command\":\"launch\",\"seq\":2,\"type\":"
+        "\"request\"}",
+        "{\"arguments\":{},\"command\":\"configurationDone\",\"seq\":3,"
+        "\"type\":"
+        "\"request\"}" });
+
+    // Wait until CMake generation complete.
+    std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+
+    // Send disconnect command.
+    sendCommands(
+      debugger, 200,
+      { "{\"arguments\":{},\"command\":\"disconnect\",\"seq\":4,\"type\":"
+        "\"request\"}" });
+
+    // Read response from the debugger.
+    while (true) {
+      char buffer[1];
+      if (debugger->read(buffer, 1) != 1) {
+        std::cout << "debugger read error: " << GetLastError() << std::endl;
+        break;
+      }
+      debuggerResponseStream << buffer[0];
+    }
+
+    debugger->close();
+    CloseHandle(pipe);
+
+    return 0;
+  });
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(300));
+  STARTUPINFOW si;
+  PROCESS_INFORMATION pi;
+
+  ZeroMemory(&si, sizeof(si));
+  si.cb = sizeof(si);
+  ZeroMemory(&pi, sizeof(pi));
+
+  std::cout << "Running command: " << cmakeCommand << std::endl;
+
+  // Start the CMake process.
+  if (!CreateProcessW(
+        NULL, // No module name (use command line)
+        cmsys::Encoding::ToWide(cmakeCommand.c_str()).data(), // Command line
+        NULL,  // Process handle not inheritable
+        NULL,  // Thread handle not inheritable
+        FALSE, // Set handle inheritance to FALSE
+        0,     // No creation flags
+        NULL,  // Use parent's environment block
+        cmsys::Encoding::ToWide(argv[4])
+          .data(), // Use parent's starting directory
+        &si,       // Pointer to STARTUPINFO structure
+        &pi)       // Pointer to PROCESS_INFORMATION structure
+  ) {
+    std::cout << "Error running command " << GetLastError() << std::endl;
+    return -1;
+  }
+
+  // Wait until CMake process exits.
+  WaitForSingleObject(pi.hProcess, timeout);
+
+  CloseHandle(pi.hProcess);
+  CloseHandle(pi.hThread);
+  clientThread.join();
+
+  auto debuggerResponse = debuggerResponseStream.str();
+
+  std::vector<std::string> expectedResponses = {
+    "\"event\":\"initialized\".*\"type\":\"event\"",
+    "\"command\":\"launch\".*\"success\":true.*\"type\":\"response\"",
+    "\"command\":\"configurationDone\".*\"success\":true.*\"type\":"
+    "\"response\"",
+    "\"reason\":\"started\".*\"threadId\":1.*\"event\":\"thread\".*"
+    "\"type\":\"event\"",
+    "\"reason\":\"exited\".*\"threadId\":1.*\"event\":\"thread\".*"
+    "\"type\":\"event\"",
+    "\"exitCode\":0.*\"event\":\"exited\".*\"type\":\"event\"",
+    "\"command\":\"disconnect\".*\"success\":true.*\"type\":\"response\""
+  };
+
+  for (auto& regexString : expectedResponses) {
+    std::regex regex(regexString);
+    if (!std::regex_search(debuggerResponse, regex)) {
+      std::cout << "Expected response not found: " << regexString << std::endl;
+      std::cout << debuggerResponse << std::endl;
+      return -1;
+    }
+  }
+
+  return 0;
+}


### PR DESCRIPTION
Support Named Pipe for DAP Traffics on Windows

- Part of #1730304
- Include unit test.

![image](https://user-images.githubusercontent.com/105310954/224837908-10cb984c-43e2-401d-a2ae-c6b7d7a8afb3.png)
![image](https://user-images.githubusercontent.com/105310954/224836289-fa779731-2782-4a6f-96b3-d7b675f03fc7.png)


Thanks for your interest in contributing to CMake!  The GitHub repository
is a mirror provided for convenience, but CMake does not use GitHub pull
requests for contribution.  Please see

  https://gitlab.kitware.com/cmake/cmake/-/tree/master/CONTRIBUTING.rst

for contribution instructions.  GitHub OAuth may be used to sign in.
