### PR TITLE
Fix Semmle issue: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1824942

### DIFF
--- a/Utilities/cmnghttp2/lib/nghttp2_map.c
+++ b/Utilities/cmnghttp2/lib/nghttp2_map.c
@@ -144,7 +144,7 @@ void nghttp2_map_print_distance(nghttp2_map *map) {
 
     idx = h2idx(bkt->hash, map->tablelenbits);
     fprintf(stderr, "@%u hash=%08x key=%d base=%zu distance=%zu\n", i,
-            bkt->hash, bkt->key, idx,
+            bkt->hash, (uint32_t)(bkt->key), idx,
             distance(map->tablelen, map->tablelenbits, bkt, idx));
   }
 }


### PR DESCRIPTION
The %08x is using the `x` modifier for `fprintf`, which is requesting an "unsigned hexadecimal integer". However, `bkt->key` is of type `size_t`, so we need to cast it in order to avoid the Semmle warning. 