### PR TITLE
Detect Git from Visual Studio

### DIFF
--- a/Modules/FindGit.cmake
+++ b/Modules/FindGit.cmake
@@ -48,6 +48,8 @@ if(CMAKE_HOST_WIN32)
       )
     # SourceTree search path for Windows
     set(_git_sourcetree_path "$ENV{LOCALAPPDATA}/Atlassian/SourceTree/git_local/bin")
+    # Visual Studio paths
+    set(_git_visual_studio_path "$ENV{ProgramFiles}/Microsoft Visual Studio/*/*/Common7/IDE/CommonExtensions/Microsoft/TeamFoundation/Team Explorer/Git/cmd/")
   endif()
 endif()
 
@@ -55,6 +57,7 @@ endif()
 find_program(GIT_EXECUTABLE
   NAMES ${git_names}
   PATHS ${github_path} ${_git_sourcetree_path}
+    ${_git_visual_studio_path}
   DOC "Git command line client"
   )
 


### PR DESCRIPTION
This patch allows CMake to find Git.exe that is bundled with Microsoft Visual Studio.
This is useful when other Git is not installed or not in PATH.
This patch also makes FetchContent work with bundled Git.exe in such situations.