### PR TITLE
Fixes semmle 1874861

### DIFF
--- a/Utilities/cmcurl/lib/cf-h2-proxy.c
+++ b/Utilities/cmcurl/lib/cf-h2-proxy.c
@@ -909,7 +909,7 @@ static CURLcode proxy_h2_submit(int32_t *pstream_id,
 {
   struct dynhds h2_headers;
   nghttp2_nv *nva = NULL;
-  unsigned int i;
+  size_t i;
   int32_t stream_id = -1;
   size_t nheader;
   CURLcode result;


### PR DESCRIPTION
Fixes [1874861](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1870461/?view=edit). Prevents possible infinite loop by changing the two vars being compared to the same type.