### PR TITLE
Update null reference check -  Returns error if data is null

### DIFF
--- a/Utilities/cmlibarchive/libarchive/archive_read_support_format_7zip.c
+++ b/Utilities/cmlibarchive/libarchive/archive_read_support_format_7zip.c
@@ -1072,10 +1072,7 @@ ppmd_read(void *p)
 		ssize_t bytes_avail = 0;
 		const uint8_t* data = __archive_read_ahead(a,
 		    zip->ppstream.stream_in+1, &bytes_avail);
-		if(data == NULL) {
-			return (0);
-		}
-		if(bytes_avail < zip->ppstream.stream_in+1) {
+		if(data == NULL || bytes_avail < zip->ppstream.stream_in+1) {
 			archive_set_error(&a->archive,
 			    ARCHIVE_ERRNO_FILE_FORMAT,
 			    "Truncated 7z file data");

--- a/Utilities/cmlibarchive/libarchive/archive_read_support_format_7zip.c
+++ b/Utilities/cmlibarchive/libarchive/archive_read_support_format_7zip.c
@@ -1072,6 +1072,7 @@ ppmd_read(void *p)
 		ssize_t bytes_avail = 0;
 		const uint8_t* data = __archive_read_ahead(a,
 		    zip->ppstream.stream_in+1, &bytes_avail);
+		// CodeQL [SM02311] Added NULL check for data to check for unguarded NULL reference
 		if(data == NULL || bytes_avail < zip->ppstream.stream_in+1) {
 			archive_set_error(&a->archive,
 			    ARCHIVE_ERRNO_FILE_FORMAT,


### PR DESCRIPTION
Update to #158 from comments in libarchive. Returns error if data is null instead of just return 0