### PR TITLE
Debugger: Add Value Formatting support for StackTrace request

### DIFF
--- a/Source/cmDebuggerAdapter.cxx
+++ b/Source/cmDebuggerAdapter.cxx
@@ -148,6 +148,7 @@ cmDebuggerAdapter::cmDebuggerAdapter(
     SupportsVariableType = req.supportsVariableType.value(false);
     dap::CMakeInitializeResponse response;
     response.supportsConfigurationDoneRequest = true;
+    response.supportsValueFormattingOptions = true;
     response.cmakeVersion.major = CMake_VERSION_MAJOR;
     response.cmakeVersion.minor = CMake_VERSION_MINOR;
     response.cmakeVersion.patch = CMake_VERSION_PATCH;
@@ -186,7 +187,7 @@ cmDebuggerAdapter::cmDebuggerAdapter(
     std::unique_lock<std::mutex> lock(Mutex);
 
     cm::optional<dap::StackTraceResponse> response =
-      ThreadManager->GetThreadStackTraceResponse(request.threadId);
+      ThreadManager->GetThreadStackTraceResponse(request);
     if (response.has_value()) {
       return response.value();
     }

--- a/Source/cmDebuggerStackFrame.cxx
+++ b/Source/cmDebuggerStackFrame.cxx
@@ -25,4 +25,10 @@ int64_t cmDebuggerStackFrame::GetLine() const noexcept
   return this->Function.Line();
 }
 
+std::vector<cmListFileArgument> const& cmDebuggerStackFrame::GetArguments()
+  const noexcept
+{
+  return this->Function.Arguments();
+}
+
 } // namespace cmDebugger

--- a/Source/cmDebuggerStackFrame.h
+++ b/Source/cmDebuggerStackFrame.h
@@ -7,8 +7,10 @@
 #include <atomic>
 #include <cstdint>
 #include <string>
+#include <vector>
 
 class cmListFileFunction;
+struct cmListFileArgument;
 class cmMakefile;
 
 namespace cmDebugger {
@@ -32,6 +34,7 @@ public:
   {
     return this->Function;
   }
+  std::vector<cmListFileArgument> const& GetArguments() const noexcept;
 };
 
 } // namespace cmDebugger

--- a/Source/cmDebuggerThread.h
+++ b/Source/cmDebuggerThread.h
@@ -23,6 +23,11 @@ class cmDebuggerVariables;
 class cmDebuggerVariablesManager;
 }
 
+namespace dap {
+template <typename T>
+class optional;
+}
+
 namespace cmDebugger {
 
 class cmDebuggerThread
@@ -53,7 +58,8 @@ public:
   dap::VariablesResponse GetVariablesResponse(
     dap::VariablesRequest const& request);
   friend dap::StackTraceResponse GetStackTraceResponse(
-    std::shared_ptr<cmDebuggerThread> const& thread);
+    std::shared_ptr<cmDebuggerThread> const& thread,
+    dap::optional<dap::StackFrameFormat> format);
 };
 
 } // namespace cmDebugger

--- a/Source/cmDebuggerThreadManager.cxx
+++ b/Source/cmDebuggerThreadManager.cxx
@@ -6,6 +6,7 @@
 #include <algorithm>
 
 #include <cm3p/cppdap/protocol.h>
+#include <cm3p/cppdap/types.h>
 
 #include "cmDebuggerThread.h"
 
@@ -30,18 +31,19 @@ void cmDebuggerThreadManager::EndThread(
 }
 
 cm::optional<dap::StackTraceResponse>
-cmDebuggerThreadManager::GetThreadStackTraceResponse(int64_t id)
+cmDebuggerThreadManager::GetThreadStackTraceResponse(
+  const dap::StackTraceRequest& request)
 {
   auto it = find_if(Threads.begin(), Threads.end(),
                     [&](const std::shared_ptr<cmDebuggerThread>& t) {
-                      return t->GetId() == id;
+                      return t->GetId() == request.threadId;
                     });
 
   if (it == Threads.end()) {
     return {};
   }
 
-  return GetStackTraceResponse(*it);
+  return GetStackTraceResponse(*it, request.format);
 }
 
 } // namespace cmDebugger

--- a/Source/cmDebuggerThreadManager.h
+++ b/Source/cmDebuggerThreadManager.h
@@ -17,6 +17,7 @@ class cmDebuggerThread;
 }
 
 namespace dap {
+struct StackTraceRequest;
 struct StackTraceResponse;
 }
 
@@ -32,7 +33,7 @@ public:
   std::shared_ptr<cmDebuggerThread> StartThread(std::string const& name);
   void EndThread(std::shared_ptr<cmDebuggerThread> const& thread);
   cm::optional<dap::StackTraceResponse> GetThreadStackTraceResponse(
-    std::int64_t id);
+    const dap::StackTraceRequest& request);
 };
 
 } // namespace cmDebugger

--- a/Tests/CMakeLib/testDebuggerAdapter.cxx
+++ b/Tests/CMakeLib/testDebuggerAdapter.cxx
@@ -134,6 +134,7 @@ bool runTest(std::function<bool(dap::Session&)> onThreadExitedEvent)
   ASSERT_TRUE(initializeResponse.response.supportsExceptionInfoRequest);
   ASSERT_TRUE(
     initializeResponse.response.exceptionBreakpointFilters.has_value());
+  ASSERT_TRUE(initializeResponse.response.supportsValueFormattingOptions);
 
   dap::LaunchRequest launchRequest;
   auto launchResponse = client->send(launchRequest).get();


### PR DESCRIPTION
Add support for the "format" property of the Debug Adapter Protocol StackTrace request to fulfill the host's request to format the resulting StackFrame name differently.

Cherry-pick of https://gitlab.kitware.com/cmake/cmake/-/merge_requests/9940
