### PR TITLE
updated Linux tests to work with new container image

### DIFF
--- a/Tests/BundleUtilities/bundleutils.cmake
+++ b/Tests/BundleUtilities/bundleutils.cmake
@@ -33,6 +33,31 @@ function(gp_item_default_embedded_path_override item path)
   set(path "@executable_path" PARENT_SCOPE)
 endfunction()
 
+# CI tooling such as CodeQL may inject shared libraries (via LD_PRELOAD)
+# that get picked up by get_prerequisites as dependencies of the executable.
+# These are not real application dependencies. Use the
+# gp_resolved_file_type_override hook to classify any LD_PRELOAD'd libraries
+# as "system" so that fixup_bundle skips them during bundling and verification.
+set(_preload_basenames)
+if(DEFINED ENV{LD_PRELOAD})
+  string(REPLACE ":" ";" _preload_list "$ENV{LD_PRELOAD}")
+  foreach(_preload_lib IN LISTS _preload_list)
+    if(_preload_lib)
+      get_filename_component(_preload_name "${_preload_lib}" NAME)
+      list(APPEND _preload_basenames "${_preload_name}")
+    endif()
+  endforeach()
+endif()
+
+function(gp_resolved_file_type_override resolved_file type_var)
+  if(_preload_basenames)
+    get_filename_component(_resolved_name "${resolved_file}" NAME)
+    if(_resolved_name IN_LIST _preload_basenames)
+      set(${type_var} "system" PARENT_SCOPE)
+    endif()
+  endif()
+endfunction()
+
 include(BundleUtilities)
 fixup_bundle("${OUTPUT}" "${OUTPUT_MODULE}" "${INPUTDIR}")
 

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -2926,6 +2926,15 @@ if(BUILD_TESTING)
   endif()
   set_tests_properties(CTestTestBadExe PROPERTIES
     PASS_REGULAR_EXPRESSION "${CTestTestBadExe_REGEX}")
+    
+  # CI tooling such as CodeQL may inject libraries via LD_PRELOAD that alter
+  # process execution error reporting, preventing the BAD_COMMAND string from
+  # appearing in the output. Clear LD_PRELOAD for this test so that the
+  # expected error path is taken.
+  if(DEFINED ENV{LD_PRELOAD})
+    set_tests_properties(CTestTestBadExe PROPERTIES
+      ENVIRONMENT "LD_PRELOAD=")
+  endif()
 
   configure_file(
     "${CMake_SOURCE_DIR}/Tests/CTestTestBadGenerator/test.cmake.in"

--- a/Tests/RunCMake/configure_file/NoSourcePermissions.cmake
+++ b/Tests/RunCMake/configure_file/NoSourcePermissions.cmake
@@ -1,10 +1,34 @@
 configure_file(NoSourcePermissions.sh NoSourcePermissions.sh.out
                NO_SOURCE_PERMISSIONS)
 
-if (UNIX AND NOT MSYS)
-  execute_process(COMMAND ${CMAKE_CURRENT_BINARY_DIR}/NoSourcePermissions.sh.out
-                  RESULT_VARIABLE result)
-  if (result EQUAL "0")
-    message(FATAL_ERROR "Copied file has executable permissions")
+if (CMAKE_HOST_UNIX AND NOT MSYS)
+  find_program(STAT_EXECUTABLE NAMES stat)
+  if(NOT STAT_EXECUTABLE)
+    return()
+  endif()
+
+  # NO_SOURCE_PERMISSIONS should produce 0644 (owner rw, group r, world r).
+  # Check file permissions directly using stat (consistent with
+  # SourcePermissions.cmake and UseSourcePermissions.cmake) rather than
+  # attempting to execute the file, which can give false results when CI
+  # tooling (e.g. CodeQL) injects LD_PRELOAD libraries that alter process
+  # execution.
+  if (CMAKE_HOST_SYSTEM_NAME MATCHES "FreeBSD")
+    execute_process(COMMAND "${STAT_EXECUTABLE}" -f %Lp "${CMAKE_CURRENT_BINARY_DIR}/NoSourcePermissions.sh.out"
+      OUTPUT_VARIABLE output OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+  elseif(CMAKE_HOST_SYSTEM_NAME MATCHES "Darwin")
+    execute_process(COMMAND "${STAT_EXECUTABLE}" -f %A "${CMAKE_CURRENT_BINARY_DIR}/NoSourcePermissions.sh.out"
+      OUTPUT_VARIABLE output OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+  else()
+    execute_process(COMMAND "${STAT_EXECUTABLE}" -c %a "${CMAKE_CURRENT_BINARY_DIR}/NoSourcePermissions.sh.out"
+      OUTPUT_VARIABLE output OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+  endif()
+
+  # Verify no executable bits are set (expected: 644)
+  if (NOT output EQUAL "644")
+    message(FATAL_ERROR "Copied file has unexpected permissions: ${output}, expected 644")
   endif()
 endif()

--- a/VSInsertion/Packaging/cgmanifest.json
+++ b/VSInsertion/Packaging/cgmanifest.json
@@ -5,7 +5,7 @@
                 "Type": "git",
                 "Git": {
                     "RepositoryUrl": "https://github.com/microsoft/CMake.git",
-                    "CommitHash": "cea9a87bc974c117a72a4fd044e0cc0b28ccfcf3"
+                    "CommitHash": "d1382862ab75076693ac534420626d17bb303ed2"
                 }
             }
         }


### PR DESCRIPTION
This PR is to update the failing Linux tests to work with the new container image ubuntu-24.0.4