### PR TITLE
Scope SBoM and Component Governance scans to non-C++ source directories

### DIFF
--- a/VSInsertion/Packaging/cgmanifest.json
+++ b/VSInsertion/Packaging/cgmanifest.json
@@ -5,7 +5,7 @@
                 "Type": "git",
                 "Git": {
                     "RepositoryUrl": "https://github.com/microsoft/CMake.git",
-                    "CommitHash": "4fe28dc1e760d8e63c5ce17b3b061333c2846a8a"
+                    "CommitHash": "544cf1c1a98f448372eb0581bee28df2faa09e16"
                 }
             }
         }

--- a/VSInsertion/Pipelines/build.yml
+++ b/VSInsertion/Pipelines/build.yml
@@ -50,6 +50,8 @@ variables:
   value: true
 - name: Codeql.Language
   value: cpp,csharp,javascript,powershell,python,ruby
+- name: ComponentDetection.SourcePath
+  value: $(Build.SourcesDirectory)/VSInsertion
 - name: DisableDockerDetector
   value: true
 - name: PackagingSolutionRoot
@@ -90,12 +92,16 @@ extends:
         pool:
           name: VSEngSS-MicroBuild2022-1ES
         templateContext:
+          sdl:
+            sbom:
+              BuildComponentPath: '$(ArchiveDir)'
           outputs:
           - output: pipelineArtifact
             displayName: 'Publish CMake x64 Artifact'
             targetPath: $(ArchiveDir)
             artifactName: CMakeX64
             codeSignValidationEnabled: false
+            sbomBuildDropPath: $(ArchiveDir)
         steps:
         - checkout: self
           clean: true
@@ -210,12 +216,16 @@ extends:
         pool:
           name: VSEngSS-MicroBuild2022-1ES
         templateContext:
+          sdl:
+            sbom:
+              BuildComponentPath: '$(ArchiveDir)'
           outputs:
           - output: pipelineArtifact
             displayName: 'Publish CMake ARM64 Artifact'
             targetPath: $(ArchiveDir)
             artifactName: CMakeArm64
             codeSignValidationEnabled: false
+            sbomBuildDropPath: $(ArchiveDir)
         steps:
         - checkout: self
           clean: true
@@ -275,12 +285,16 @@ extends:
         pool:
           name: VSEngSS-MicroBuild2022-1ES
         templateContext:
+          sdl:
+            sbom:
+              BuildComponentPath: '$(ArchiveDir)'
           outputs:
           - output: pipelineArtifact
             displayName: 'Publish CMake x86 Artifact'
             targetPath: $(ArchiveDir)
             artifactName: CMakeX86
             codeSignValidationEnabled: false
+            sbomBuildDropPath: $(ArchiveDir)
         steps:
         - checkout: self
           clean: true


### PR DESCRIPTION
Fixes false-positive CG alert **MVS-2026-qx3q-rvv6** flagging `VC-Tools-MSVC 14.34.31933` against `MicrosoftCMake_cmake-daemon`. CMake does not link with that toolset; it was registered because the auto-injected `CppSdkDetector` enumerates every MSVC SxS install on the build agent whenever it spots any `*.c`/`*.cpp`/`*.cxx`/`*.vcxproj` in its scan root.

**Confirmed in the `CMake x64 Cache Generation` task of build 14277016**, CMake actually links with `14.42.34433` (the default `v143` toolset shipped with VS 17.14 on the `VSEngSS-MicroBuild2022-1ES` image):
```
-- The C compiler identification is MSVC 19.42.34444.0
-- The CXX compiler identification is MSVC 19.42.34444.0
-- Check for working C compiler:
   C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Tools/MSVC/14.42.34433/bin/HostX64/x64/cl.exe
-- Check for working CXX compiler:
   C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Tools/MSVC/14.42.34433/bin/HostX64/x64/cl.exe
```
Zero occurrences of the alerted `14.34.31933` appear in any of the configure/build/SBoM/CG logs — it lives only as an idle side-by-side install on the agent image.

**Fix — point both scans at directories that contain no C/C++ source:**

| Step | Config added | Where |
|---|---|---|
| 🛡 Generate SBoM Manifest | `templateContext.sdl.sbom.BuildComponentPath: $(ArchiveDir)` + per-output `sbomBuildDropPath: $(ArchiveDir)` | `Job_x64`, `Job_arm64`, `Job_x86` |
| 🛡 Component Governance | `ComponentDetection.SourcePath: $(Build.SourcesDirectory)/VSInsertion` | top-level `variables:` |

`$(ArchiveDir)` only holds the built CMake binaries. `VSInsertion/` holds the legitimate CG inputs (`cgmanifest.json`, `Signing/packages.config`) and zero C/C++/.vcxproj files, so `CgManifest` and `NuGetPackagesConfig` continue to fire while `CppSdk` reports `0 | 0`.

`Job_Final` is unchanged (its `Symbols` output already scopes `sbomBuildDropPath`).

**Verified** on build 14277016 across x64/arm64/x86:
- SBoM: `BuildComponentPath = D:\a\_work\1\a\archive`, `CppSdk (Beta) = 0 | 0`, `TotalNumberOfPackages = 3` (was 9 — 6 false-positive MSVC toolsets dropped).
- CG: `--SourceDirectory D:\a\_work\1\s\VSInsertion`, `CppSdk = 0 | 0`.
- Zero `Scanning MSVC toolsets…` / `Found MSVC toolset…` lines in any of the 6 logs.
- `CgManifest = 1 | 1` and `NuGetPackagesConfig = 1 | 1` preserved in both steps.

**Files changed (15 net lines):**
- `VSInsertion/Pipelines/build.yml`
- `VSInsertion/Packaging/cgmanifest.json` (CommitHash bumped to fix commit)

---

Work item: AB#2992623  
CG alert: MVS-2026-qx3q-rvv6 (alertId 13858911, repo id 113867)
